### PR TITLE
Add Portland publish scheduling and harden shared TTS playback

### DIFF
--- a/app/api/tts/audio/[type]/[slug]/route.ts
+++ b/app/api/tts/audio/[type]/[slug]/route.ts
@@ -6,7 +6,7 @@ export const dynamic = 'force-dynamic';
 const TTS_BASE = 'http://127.0.0.1:8888';
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ type: string; slug: string }> }
 ) {
   try {
@@ -19,9 +19,18 @@ export async function GET(
       );
     }
 
+    const upstreamHeaders = new Headers();
+    const range = request.headers.get('range');
+    if (range) {
+      upstreamHeaders.set('Range', range);
+    }
+
     const upstream = await fetch(
       `${TTS_BASE}/audio/${encodeURIComponent(type)}/${encodeURIComponent(slug)}`,
-      { cache: 'no-store' }
+      {
+        cache: 'no-store',
+        headers: upstreamHeaders,
+      }
     );
 
     if (upstream.status === 404) {
@@ -38,15 +47,13 @@ export async function GET(
       );
     }
 
-    const audioBuffer = await upstream.arrayBuffer();
+    const responseHeaders = new Headers(upstream.headers);
+    responseHeaders.set('Cache-Control', 'public, max-age=86400');
+    responseHeaders.set('Content-Disposition', `inline; filename="${slug}.wav"`);
 
-    return new NextResponse(audioBuffer, {
-      status: 200,
-      headers: {
-        'Content-Type': 'audio/wav',
-        'Cache-Control': 'public, max-age=86400',
-        'Content-Disposition': `inline; filename="${slug}.wav"`,
-      },
+    return new NextResponse(upstream.body, {
+      status: upstream.status,
+      headers: responseHeaders,
     });
   } catch (error) {
     const message =

--- a/app/blog/[slug]/PostPageClient.tsx
+++ b/app/blog/[slug]/PostPageClient.tsx
@@ -11,9 +11,15 @@ import type { ParsedPost } from '@/lib/blog/parser';
 
 interface PostPageClientProps {
   post: ParsedPost;
+  isScheduledPreview?: boolean;
+  scheduledPublishDate?: string;
 }
 
-export function PostPageClient({ post }: PostPageClientProps) {
+export function PostPageClient({
+  post,
+  isScheduledPreview = false,
+  scheduledPublishDate,
+}: PostPageClientProps) {
   const router = useRouter();
   
   const handleClose = () => {
@@ -25,6 +31,8 @@ export function PostPageClient({ post }: PostPageClientProps) {
     <PostView
       post={post}
       onClose={handleClose}
+      isScheduledPreview={isScheduledPreview}
+      scheduledPublishDate={scheduledPublishDate}
     />
   );
 }

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@
  */
 
 import { loadAllPosts, getPostBySlug } from '@/lib/blog/loader';
+import { extractIsoDateFromBlogFilename, formatLongDate, getPublishState } from '@/lib/content/publish';
 import { notFound } from 'next/navigation';
 import { PostPageClient } from './PostPageClient';
 
@@ -15,7 +16,7 @@ export const dynamic = 'force-dynamic';
  * Generate static params for all posts at build time
  */
 export async function generateStaticParams() {
-  const posts = await loadAllPosts();
+  const posts = await loadAllPosts(undefined, { includeScheduled: true });
   return posts.map(post => ({
     slug: post.filename.replace('.md', '')
   }));
@@ -23,7 +24,7 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
-  const allPosts = await loadAllPosts();
+  const allPosts = await loadAllPosts(undefined, { includeScheduled: true });
   const post = getPostBySlug(allPosts, slug);
 
   if (!post) {
@@ -32,27 +33,16 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     };
   }
 
-  // Extract date logic (similar to PostView)
-  let date: Date = new Date();
-
-  // Try to extract from filename first
-  const match = post.filename.match(/(\d{4}-\d{2}-\d{2})/);
-  if (match?.[1]) {
-    date = new Date(match[1]);
-  } else if (post.metadata.date !== undefined) {
-    // Fall back to metadata.date if it exists
-    date = new Date(post.metadata.date);
-  }
-
-  const formattedDate = date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+  const publishState = getPublishState(extractIsoDateFromBlogFilename(post.filename));
+  const formattedDate = formatLongDate(publishState.publishDate) ?? 'Unknown Date';
 
   return {
-    title: `Midori AI Blog - ${formattedDate}`,
-    description: post.metadata.summary || post.metadata.title,
+    title: publishState.isScheduled
+      ? `Midori AI Blog - Scheduled for ${formattedDate}`
+      : `Midori AI Blog - ${formattedDate}`,
+    description: publishState.isScheduled
+      ? `This post is scheduled for ${formattedDate} in Portland time.`
+      : post.metadata.summary || post.metadata.title,
   };
 }
 
@@ -68,7 +58,7 @@ export default async function PostPage({
   const { slug } = await params;
 
   // Load all posts and find the requested one
-  const allPosts = await loadAllPosts();
+  const allPosts = await loadAllPosts(undefined, { includeScheduled: true });
   const post = getPostBySlug(allPosts, slug);
 
   // Handle 404 for non-existent posts
@@ -76,7 +66,13 @@ export default async function PostPage({
     notFound();
   }
 
+  const publishState = getPublishState(extractIsoDateFromBlogFilename(post.filename));
+
   return (
-    <PostPageClient post={post} />
+    <PostPageClient
+      post={post}
+      isScheduledPreview={publishState.isScheduled}
+      scheduledPublishDate={publishState.publishDate ?? undefined}
+    />
   );
 }

--- a/app/lore/[slug]/LorePostPageClient.tsx
+++ b/app/lore/[slug]/LorePostPageClient.tsx
@@ -7,9 +7,15 @@ import type { ParsedPost } from '@/lib/blog/parser';
 
 interface LorePostPageClientProps {
   post: ParsedPost;
+  isScheduledPreview?: boolean;
+  scheduledPublishDate?: string;
 }
 
-export function LorePostPageClient({ post }: LorePostPageClientProps) {
+export function LorePostPageClient({
+  post,
+  isScheduledPreview = false,
+  scheduledPublishDate,
+}: LorePostPageClientProps) {
   const router = useRouter();
 
   return (
@@ -19,6 +25,8 @@ export function LorePostPageClient({ post }: LorePostPageClientProps) {
       backButtonLabel="Back to lore"
       backButtonAriaLabel="Back to lore list"
       postType="lore"
+      isScheduledPreview={isScheduledPreview}
+      scheduledPublishDate={scheduledPublishDate}
     />
   );
 }

--- a/app/lore/[slug]/page.tsx
+++ b/app/lore/[slug]/page.tsx
@@ -6,6 +6,7 @@
 
 import { notFound } from 'next/navigation';
 
+import { getPublishState } from '@/lib/content/publish';
 import { getLorePostBySlug, loadAllLorePosts } from '@/lib/lore/loader';
 
 import { LorePostPageClient } from './LorePostPageClient';
@@ -13,7 +14,7 @@ import { LorePostPageClient } from './LorePostPageClient';
 export const dynamic = 'force-dynamic';
 
 export async function generateStaticParams() {
-  const posts = await loadAllLorePosts();
+  const posts = await loadAllLorePosts({ includeScheduled: true });
   return posts.map(post => ({
     slug: post.filename.replace('.md', ''),
   }));
@@ -21,12 +22,20 @@ export async function generateStaticParams() {
 
 export default async function LoreEntryPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
-  const allPosts = await loadAllLorePosts();
+  const allPosts = await loadAllLorePosts({ includeScheduled: true });
   const post = getLorePostBySlug(allPosts, slug);
 
   if (!post) {
     notFound();
   }
 
-  return <LorePostPageClient post={post} />;
+  const publishState = getPublishState(post.metadata.date);
+
+  return (
+    <LorePostPageClient
+      post={post}
+      isScheduledPreview={publishState.isScheduled}
+      scheduledPublishDate={publishState.publishDate ?? undefined}
+    />
+  );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@types/node": "^25.0.9",
         "@types/react": "^19.2.8",
         "@types/react-dom": "^19.2.3",
+        "happy-dom": "^20.9.0",
         "tsx": "^4.21.0",
       },
       "peerDependencies": {
@@ -264,6 +265,10 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
@@ -312,6 +317,8 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
@@ -335,6 +342,8 @@
     "get-tsconfig": ["get-tsconfig@4.13.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ=="],
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
@@ -593,6 +602,10 @@
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
 

--- a/components/blog/PostView.test.tsx
+++ b/components/blog/PostView.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { PostView } from './PostView';
+
+const mockPost = {
+  filename: '2099-12-31.md',
+  metadata: {
+    title: 'Future Dispatch',
+    summary: 'A scheduled update.',
+    tags: ['future'],
+    author: 'Becca Kay',
+    cover_image: '/blog/placeholder.png',
+  },
+  content: '# Hidden Body\n\nThis should stay hidden before publish day.',
+  rawMarkdown: '# Hidden Body\n\nThis should stay hidden before publish day.',
+};
+
+describe('PostView', () => {
+  test('scheduled preview hides markdown content and shows teaser copy', () => {
+    const html = renderToStaticMarkup(
+      <PostView
+        post={mockPost}
+        onClose={() => {}}
+        isScheduledPreview
+        scheduledPublishDate="2099-12-31"
+      />
+    );
+
+    expect(html).toContain('Scheduled for December 31, 2099');
+    expect(html).toContain('This post is already queued in the site');
+    expect(html).not.toContain('This should stay hidden before publish day.');
+  });
+});

--- a/components/blog/PostView.tsx
+++ b/components/blog/PostView.tsx
@@ -32,6 +32,11 @@ import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 import rehypeHighlight from 'rehype-highlight';
 import { ArrowLeft, Calendar, User, Tag } from 'lucide-react';
+import {
+  extractIsoDateFromBlogFilename,
+  formatLongDate,
+  normalizeIsoDateString,
+} from '@/lib/content/publish';
 import type { ParsedPost } from '../../lib/blog/parser';
 import { TtsPlayer } from './TtsPlayer';
 
@@ -49,37 +54,17 @@ export interface PostViewProps {
   backButtonAriaLabel?: string;
   /** Post type for TTS and contextual behavior */
   postType?: 'blog' | 'lore';
+  /** Whether to render a scheduled teaser instead of the full post */
+  isScheduledPreview?: boolean;
+  /** The scheduled publish date to show in teaser mode */
+  scheduledPublishDate?: string;
 }
 
 /**
- * Extract and format date from filename (YYYY-MM-DD.md format)
- * Falls back to metadata.date if filename doesn't match pattern
+ * Get the stable YYYY-MM-DD string for display and teaser logic.
  */
-function extractDate(post: ParsedPost): Date {
-  // Try to extract from filename first
-  const match = post.filename.match(/(\d{4}-\d{2}-\d{2})/);
-  if (match?.[1]) {
-    return new Date(match[1]);
-  }
-
-  // Fall back to metadata.date if it exists
-  if (post.metadata.date !== undefined) {
-    return new Date(post.metadata.date);
-  }
-
-  // Last resort: current date
-  return new Date();
-}
-
-/**
- * Format date for display
- */
-function formatDate(date: Date): string {
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+function getPostDateString(post: ParsedPost): string | undefined {
+  return extractIsoDateFromBlogFilename(post.filename) ?? normalizeIsoDateString(post.metadata.date) ?? undefined;
 }
 
 /**
@@ -252,12 +237,20 @@ export function PostView({
   backButtonLabel = 'Back to posts',
   backButtonAriaLabel = 'Back to blog list',
   postType = 'blog',
+  isScheduledPreview = false,
+  scheduledPublishDate,
 }: PostViewProps) {
   const [coverIsLandscape, setCoverIsLandscape] = useState<boolean | null>(null);
 
-  // Memoize date extraction to prevent recalculation on every render
-  const date = useMemo(() => extractDate(post), [post.filename, post.metadata.date]);
-  const formattedDate = useMemo(() => formatDate(date), [date]);
+  const dateString = useMemo(() => getPostDateString(post), [post.filename, post.metadata.date]);
+  const formattedDate = useMemo(
+    () => formatLongDate(dateString) ?? 'Unknown date',
+    [dateString]
+  );
+  const scheduledPublishLabel = useMemo(
+    () => formatLongDate(scheduledPublishDate ?? dateString) ?? formattedDate,
+    [scheduledPublishDate, dateString, formattedDate]
+  );
   const markdownContent = useMemo(
     () => replaceLoreImageTokens(post.content, post.filename),
     [post.content, post.filename]
@@ -392,7 +385,7 @@ export function PostView({
           >
             <Stack direction="row" spacing={1} alignItems="center">
               <Calendar size={16} color="var(--joy-palette-primary-400)" />
-              <Typography component="time" dateTime={date.toISOString()}>
+              <Typography component="time" dateTime={dateString}>
                 {formattedDate}
               </Typography>
             </Stack>
@@ -458,7 +451,7 @@ export function PostView({
                   width: '100%',
                   height: '100%',
                   objectFit: 'cover',
-                  filter: 'blur(20px) brightness(0.6)',
+                  filter: isScheduledPreview ? 'blur(34px) brightness(0.45)' : 'blur(20px) brightness(0.6)',
                   transform: 'scale(1.1)',
                   zIndex: 0,
                   opacity: 0.8,
@@ -490,25 +483,27 @@ export function PostView({
                   maxHeight: { xs: '22%', sm: '15%' },
                   width: 'auto',
                   display: 'block',
-                  // Remove previous shadow as the vignette handles the transition
+                  filter: isScheduledPreview ? 'blur(18px) saturate(0.72) brightness(0.7)' : 'none',
+                  transform: isScheduledPreview ? 'scale(1.08)' : 'none',
                 }}
               />
             </Card>
           )}
 
-          {/* TTS Player - full width under cover image */}
-          <Box sx={{ mb: 4 }}>
-            <TtsPlayer
-              slug={post.filename.replace(/\.md$/, '')}
-              type={postType}
-              text={post.content}
-              coverImageUrl={
-                post.metadata.cover_image
-                  ? transformImageUrl(post.metadata.cover_image)
-                  : undefined
-              }
-            />
-          </Box>
+          {!isScheduledPreview && (
+            <Box sx={{ mb: 4 }}>
+              <TtsPlayer
+                slug={post.filename.replace(/\.md$/, '')}
+                type={postType}
+                text={post.content}
+                coverImageUrl={
+                  post.metadata.cover_image
+                    ? transformImageUrl(post.metadata.cover_image)
+                    : undefined
+                }
+              />
+            </Box>
+          )}
 
           {/* Summary */}
           {post.metadata.summary && (
@@ -532,183 +527,200 @@ export function PostView({
 
         <Divider sx={{ mb: 6, bgcolor: 'rgba(255,255,255,0.1)' }} />
 
-        {/* Markdown Content */}
-        <Box
-          sx={{
-            // Typography settings for readability
-            fontSize: { xs: '1rem', sm: '1.125rem' }, // 16px on phones, 18px up
-            lineHeight: 1.8,
-            color: 'text.secondary', // Slightly softer than pure white
-
-            // Prose styling for markdown elements
-            '& h1, & h2, & h3, & h4, & h5, & h6': {
-              color: 'primary.200', // Light purple for headers
-              scrollMarginTop: '100px',
-            },
-            '& h1': {
-              fontSize: { xs: '2rem', sm: '2.5rem' },
-              fontWeight: 700,
-              mt: 6,
-              mb: 3,
-            },
-            '& h2': {
-              fontSize: { xs: '1.6rem', sm: '2rem' },
-              fontWeight: 700,
-              mt: 5,
-              mb: 2.5,
-              pb: 1,
-              borderBottom: '1px solid',
-              borderColor: 'rgba(139, 92, 246, 0.2)', // Subtle purple line
-            },
-            '& h3': {
-              fontSize: { xs: '1.25rem', sm: '1.5rem' },
-              fontWeight: 600,
-              mt: 4,
-              mb: 2,
-              color: 'primary.300',
-            },
-            '& h4': {
-              fontSize: { xs: '1.1rem', sm: '1.25rem' },
-              fontWeight: 600,
-              mt: 3,
-              mb: 1.5,
-            },
-            '& p': {
-              mb: 3,
-            },
-            '& strong': {
-              color: 'text.primary',
-              fontWeight: 600,
-            },
-            '& ul, & ol': {
-              ml: { xs: 2, sm: 3 },
-              mb: 3,
-              pl: { xs: 0.5, sm: 1 },
-              '& li': {
-                mb: 1,
-                pl: 1,
-                '&::marker': {
-                  color: 'primary.400', // Purple bullets
-                }
-              }
-            },
-            '& blockquote': {
-              borderLeft: '4px solid',
-              borderColor: 'primary.500',
-              pl: 3,
-              py: 2,
-              my: 4,
-              fontStyle: 'italic',
-              bgcolor: 'rgba(139, 92, 246, 0.05)', // Very subtle purple tint
-              color: 'text.primary',
-            },
-            '& code': {
-              // INLINE CODE STYLING (Dark Green Highlight)
-              backgroundColor: 'rgba(20, 83, 45, 0.6)',
-              color: '#4ade80', // Bright green text
-              px: 0.75,
-              py: 0.25,
-              borderRadius: 0, // Sharp
-              fontSize: '0.9rem',
-              fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+        {isScheduledPreview ? (
+          <Card
+            variant="soft"
+            color="neutral"
+            sx={{
+              p: { xs: 2, sm: 3 },
+              borderRadius: 0,
               border: '1px solid',
-              borderColor: 'rgba(74, 222, 128, 0.2)',
-
-              // Shimmer Effect
-              background: 'linear-gradient(to right, rgba(20, 83, 45, 0.6) 0%, rgba(74, 222, 128, 0.25) 50%, rgba(20, 83, 45, 0.6) 100%)',
-              backgroundSize: '1000px 100%',
-              animation: 'shimmer 6s linear infinite',
-              // Pseudo-random durations for wave effect
-              '&:nth-of-type(2n)': { animationDuration: '4s' },
-              '&:nth-of-type(3n)': { animationDuration: '8s' },
-              '&:nth-of-type(5n)': { animationDuration: '5s' },
-              '&:nth-of-type(7n)': { animationDuration: '7s' },
-            },
-            '& pre': {
-              // CODE BLOCK CONTAINER
-              backgroundColor: '#282c34 !important', // Match Atom One Dark background
-              p: 2,
-              borderRadius: 0, // Sharp
-              overflow: 'auto',
-              my: 4,
-              border: '1px solid',
-              borderColor: 'rgba(255,255,255,0.1)',
-              '& code': {
-                // Reset inline styles for code blocks
-                backgroundColor: 'transparent !important',
-                color: 'inherit',
-                p: 0,
-                border: 'none',
-                fontFamily: 'inherit',
-                background: 'none', // No shimmer on block code text
-                animation: 'none',
-              },
-              // Ensure highlight.js classes work
-              '& .hljs': {
-                background: 'transparent',
-              }
-            },
-            '& a': {
-              color: 'primary.400',
-              textDecoration: 'none',
-              borderBottom: '1px dashed',
-              borderColor: 'primary.400',
-              transition: 'all 0.2s',
-              '&:hover': {
-                color: 'primary.300',
-                backgroundColor: 'rgba(139, 92, 246, 0.1)',
-                borderBottomStyle: 'solid',
-              },
-            },
-            '& img': {
-              maxWidth: '100%',
-              height: 'auto',
-              borderRadius: 0, // Sharp
-              my: 4,
-              display: 'block',
-              border: '1px solid',
-              borderColor: 'rgba(255,255,255,0.1)',
-
-              // Shimmer on content images too
-              background: 'linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.05) 50%, rgba(255, 255, 255, 0) 100%)',
-              backgroundSize: '1000px 100%',
-              animation: 'shimmer 15s linear infinite',
-            },
-            '& hr': {
-              border: 'none',
-              borderTop: '1px solid',
-              borderColor: 'divider',
-              my: 6,
-            },
-            '& table': {
-              width: '100%',
-              borderCollapse: 'collapse',
-              my: 4,
-              display: 'block',
-              overflowX: 'auto',
-            },
-            '& th': {
-              textAlign: 'left',
-              p: 2,
-              borderBottom: '2px solid',
-              borderColor: 'primary.500',
-              color: 'primary.100',
-            },
-            '& td': {
-              p: 2,
-              borderBottom: '1px solid',
-              borderColor: 'divider',
-            },
-          }}
-        >
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeSanitize, rehypeHighlight]}
-            components={markdownComponents}
+              borderColor: 'rgba(255,255,255,0.08)',
+              bgcolor: 'rgba(255,255,255,0.03)',
+            }}
           >
-            {markdownContent}
-          </ReactMarkdown>
-        </Box>
+            <Typography level="title-lg" sx={{ mb: 1 }}>
+              Scheduled for {scheduledPublishLabel}
+            </Typography>
+            <Typography level="body-md" sx={{ color: 'text.secondary', fontSize: { xs: '1rem', sm: '1.05rem' } }}>
+              This post is already queued in the site, but it stays hidden until that date begins in Portland time.
+            </Typography>
+            <Typography level="body-sm" sx={{ mt: 1.5, color: 'text.tertiary', fontSize: '0.98rem' }}>
+              The full post content and listen-along player will unlock automatically when the publish date arrives.
+            </Typography>
+          </Card>
+        ) : (
+          <Box
+            sx={{
+              // Typography settings for readability
+              fontSize: { xs: '1rem', sm: '1.125rem' }, // 16px on phones, 18px up
+              lineHeight: 1.8,
+              color: 'text.secondary', // Slightly softer than pure white
+
+              // Prose styling for markdown elements
+              '& h1, & h2, & h3, & h4, & h5, & h6': {
+                color: 'primary.200', // Light purple for headers
+                scrollMarginTop: '100px',
+              },
+              '& h1': {
+                fontSize: { xs: '2rem', sm: '2.5rem' },
+                fontWeight: 700,
+                mt: 6,
+                mb: 3,
+              },
+              '& h2': {
+                fontSize: { xs: '1.6rem', sm: '2rem' },
+                fontWeight: 700,
+                mt: 5,
+                mb: 2.5,
+                pb: 1,
+                borderBottom: '1px solid',
+                borderColor: 'rgba(139, 92, 246, 0.2)', // Subtle purple line
+              },
+              '& h3': {
+                fontSize: { xs: '1.25rem', sm: '1.5rem' },
+                fontWeight: 600,
+                mt: 4,
+                mb: 2,
+                color: 'primary.300',
+              },
+              '& h4': {
+                fontSize: { xs: '1.1rem', sm: '1.25rem' },
+                fontWeight: 600,
+                mt: 3,
+                mb: 1.5,
+              },
+              '& p': {
+                mb: 3,
+              },
+              '& strong': {
+                color: 'text.primary',
+                fontWeight: 600,
+              },
+              '& ul, & ol': {
+                ml: { xs: 2, sm: 3 },
+                mb: 3,
+                pl: { xs: 0.5, sm: 1 },
+                '& li': {
+                  mb: 1,
+                  pl: 1,
+                  '&::marker': {
+                    color: 'primary.400', // Purple bullets
+                  }
+                }
+              },
+              '& blockquote': {
+                borderLeft: '4px solid',
+                borderColor: 'primary.500',
+                pl: 3,
+                py: 2,
+                my: 4,
+                fontStyle: 'italic',
+                bgcolor: 'rgba(139, 92, 246, 0.05)', // Very subtle purple tint
+                color: 'text.primary',
+              },
+              '& code': {
+                // INLINE CODE STYLING (Dark Green Highlight)
+                backgroundColor: 'rgba(20, 83, 45, 0.6)',
+                color: '#4ade80', // Bright green text
+                px: 0.75,
+                py: 0.25,
+                borderRadius: 0, // Sharp
+                fontSize: '0.9rem',
+                fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+                border: '1px solid',
+                borderColor: 'rgba(74, 222, 128, 0.2)',
+
+                // Shimmer Effect
+                background: 'linear-gradient(to right, rgba(20, 83, 45, 0.6) 0%, rgba(74, 222, 128, 0.25) 50%, rgba(20, 83, 45, 0.6) 100%)',
+                backgroundSize: '1000px 100%',
+                animation: 'shimmer 6s linear infinite',
+                '&:nth-of-type(2n)': { animationDuration: '4s' },
+                '&:nth-of-type(3n)': { animationDuration: '8s' },
+                '&:nth-of-type(5n)': { animationDuration: '5s' },
+                '&:nth-of-type(7n)': { animationDuration: '7s' },
+              },
+              '& pre': {
+                backgroundColor: '#282c34 !important',
+                p: 2,
+                borderRadius: 0,
+                overflow: 'auto',
+                my: 4,
+                border: '1px solid',
+                borderColor: 'rgba(255,255,255,0.1)',
+                '& code': {
+                  backgroundColor: 'transparent !important',
+                  color: 'inherit',
+                  p: 0,
+                  border: 'none',
+                  fontFamily: 'inherit',
+                  background: 'none',
+                  animation: 'none',
+                },
+                '& .hljs': {
+                  background: 'transparent',
+                }
+              },
+              '& a': {
+                color: 'primary.400',
+                textDecoration: 'none',
+                borderBottom: '1px dashed',
+                borderColor: 'primary.400',
+                transition: 'all 0.2s',
+                '&:hover': {
+                  color: 'primary.300',
+                  backgroundColor: 'rgba(139, 92, 246, 0.1)',
+                  borderBottomStyle: 'solid',
+                },
+              },
+              '& img': {
+                maxWidth: '100%',
+                height: 'auto',
+                borderRadius: 0,
+                my: 4,
+                display: 'block',
+                border: '1px solid',
+                borderColor: 'rgba(255,255,255,0.1)',
+                background: 'linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.05) 50%, rgba(255, 255, 255, 0) 100%)',
+                backgroundSize: '1000px 100%',
+                animation: 'shimmer 15s linear infinite',
+              },
+              '& hr': {
+                border: 'none',
+                borderTop: '1px solid',
+                borderColor: 'divider',
+                my: 6,
+              },
+              '& table': {
+                width: '100%',
+                borderCollapse: 'collapse',
+                my: 4,
+                display: 'block',
+                overflowX: 'auto',
+              },
+              '& th': {
+                textAlign: 'left',
+                p: 2,
+                borderBottom: '2px solid',
+                borderColor: 'primary.500',
+                color: 'primary.100',
+              },
+              '& td': {
+                p: 2,
+                borderBottom: '1px solid',
+                borderColor: 'divider',
+              },
+            }}
+          >
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeSanitize, rehypeHighlight]}
+              components={markdownComponents}
+            >
+              {markdownContent}
+            </ReactMarkdown>
+          </Box>
+        )}
       </Box>
 
       {/* Footer - Back to top */}

--- a/components/blog/TtsPlayer.test.tsx
+++ b/components/blog/TtsPlayer.test.tsx
@@ -1,0 +1,339 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Window } from 'happy-dom';
+
+import { TtsPlayer } from './TtsPlayer';
+
+type TtsState = 'not_generated' | 'generating' | 'ready';
+
+let testWindow: Window;
+let container: HTMLDivElement;
+let root: Root;
+let lastAudio: MockAudio | null = null;
+let intervalCallback: (() => void) | null = null;
+let clearIntervalCalls = 0;
+
+const originalGlobals = new Map<string, unknown>();
+const originalSetInterval = globalThis.setInterval;
+const originalClearInterval = globalThis.clearInterval;
+
+class MockAudio {
+  src = '';
+  duration = 75;
+  currentTime = 0;
+  private listeners = new Map<string, Set<(event: Event) => void>>();
+
+  constructor() {
+    lastAudio = this;
+  }
+
+  load() {
+    this.emit('loadedmetadata');
+  }
+
+  async play() {
+    this.emit('playing');
+    return;
+  }
+
+  pause() {
+    this.emit('pause');
+  }
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    const listeners = this.listeners.get(type) ?? new Set<(event: Event) => void>();
+    const normalized =
+      typeof listener === 'function'
+        ? listener
+        : (event: Event) => listener.handleEvent(event);
+    listeners.add(normalized);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    const listeners = this.listeners.get(type);
+    if (!listeners) return;
+
+    for (const current of listeners) {
+      if (current === listener || (typeof listener !== 'function' && current === listener.handleEvent)) {
+        listeners.delete(current);
+      }
+    }
+  }
+
+  private emit(type: string) {
+    const event = new Event(type);
+    const listeners = this.listeners.get(type);
+    if (!listeners) return;
+
+    for (const listener of listeners) {
+      listener(event);
+    }
+  }
+}
+
+function installDom() {
+  testWindow = new Window({ url: 'http://localhost:3000' });
+
+  const assignments: Record<string, unknown> = {
+    window: testWindow,
+    document: testWindow.document,
+    navigator: testWindow.navigator,
+    Node: testWindow.Node,
+    Text: testWindow.Text,
+    HTMLElement: testWindow.HTMLElement,
+    HTMLDivElement: testWindow.HTMLDivElement,
+    Event: testWindow.Event,
+    MouseEvent: testWindow.MouseEvent,
+    KeyboardEvent: testWindow.KeyboardEvent,
+    MutationObserver: testWindow.MutationObserver,
+    SyntaxError,
+    getComputedStyle: testWindow.getComputedStyle.bind(testWindow),
+    requestAnimationFrame: (cb: FrameRequestCallback) =>
+      setTimeout(() => cb(Date.now()), 0),
+    cancelAnimationFrame: (id: number) => clearTimeout(id),
+    Audio: MockAudio,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  };
+
+  for (const [key, value] of Object.entries(assignments)) {
+    originalGlobals.set(key, (globalThis as Record<string, unknown>)[key]);
+    (globalThis as Record<string, unknown>)[key] = value;
+  }
+
+  testWindow.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as typeof testWindow.matchMedia;
+  testWindow.scrollTo = () => {};
+}
+
+function restoreDom() {
+  for (const [key, value] of originalGlobals.entries()) {
+    if (value === undefined) {
+      delete (globalThis as Record<string, unknown>)[key];
+      continue;
+    }
+    (globalThis as Record<string, unknown>)[key] = value;
+  }
+  originalGlobals.clear();
+}
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function setFetchMock(handler: (url: string, init?: RequestInit) => Promise<Response> | Response) {
+  originalGlobals.set('fetch', globalThis.fetch);
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) =>
+    handler(String(input), init)) as typeof fetch;
+}
+
+async function flushEffects() {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function renderPlayer() {
+  await act(async () => {
+    root.render(<TtsPlayer slug="shared-post" type="blog" text="Hello world" />);
+    await flushEffects();
+  });
+}
+
+async function waitForElement<T>(
+  getter: () => T | null,
+  failureMessage: string
+): Promise<T> {
+  const deadline = Date.now() + 1000;
+
+  while (Date.now() < deadline) {
+    const element = getter();
+    if (element) return element;
+
+    await act(async () => {
+      await flushEffects();
+    });
+  }
+
+  throw new Error(`${failureMessage}\n${container.innerHTML}`);
+}
+
+function getVisibleGeneratingBar() {
+  return getAllElements(container).find(
+    (element) =>
+      element.getAttribute('role') === 'progressbar' &&
+      element.getAttribute('aria-hidden') === 'false'
+  ) ?? null;
+}
+
+function getVisibleListenButton() {
+  return getAllElements(container).find(
+    (element) =>
+      element.getAttribute('role') === 'button' &&
+      element.getAttribute('aria-label') === 'Generate audio for this post' &&
+      element.getAttribute('aria-hidden') === 'false'
+  ) ?? null;
+}
+
+function getVisibleReadyButton(label: 'Play' | 'Pause') {
+  const activeContainer = getAllElements(container).find(
+    (element) => element.getAttribute('aria-hidden') === 'false'
+  );
+  if (!activeContainer) return null;
+
+  return getAllElements(activeContainer).find(
+    (element) =>
+      element.tagName.toLowerCase() === 'button' &&
+      element.getAttribute('aria-label') === label
+  ) ?? null;
+}
+
+function getAllElements(rootElement: Element) {
+  const elements: Element[] = [];
+  const stack: Element[] = [rootElement];
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    const children = Array.from(current.children);
+
+    for (const child of children) {
+      elements.push(child);
+      stack.push(child);
+    }
+  }
+
+  return elements;
+}
+
+beforeEach(() => {
+  installDom();
+  lastAudio = null;
+  intervalCallback = null;
+  clearIntervalCalls = 0;
+
+  container = testWindow.document.createElement('div');
+  testWindow.document.body.appendChild(container);
+  root = createRoot(container);
+
+  globalThis.setInterval = ((handler: TimerHandler) => {
+    intervalCallback =
+      typeof handler === 'function' ? (handler as () => void) : null;
+    return 1 as unknown as ReturnType<typeof setInterval>;
+  }) as typeof setInterval;
+
+  globalThis.clearInterval = (() => {
+    clearIntervalCalls += 1;
+    intervalCallback = null;
+  }) as typeof clearInterval;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+    await flushEffects();
+  });
+  container.remove();
+  restoreDom();
+  globalThis.setInterval = originalSetInterval;
+  globalThis.clearInterval = originalClearInterval;
+});
+
+describe('TtsPlayer', () => {
+  test('shows the generating bar immediately when another visitor already started generation', async () => {
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) {
+        return jsonResponse({ status: 'generating' satisfies TtsState });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer();
+
+    expect(getVisibleGeneratingBar()).not.toBeNull();
+  });
+
+  test('transitions from generating to ready when polling sees completed audio', async () => {
+    const statuses: TtsState[] = ['generating', 'ready'];
+
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) {
+        return jsonResponse({
+          status: statuses.shift() ?? 'ready',
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer();
+
+    expect(await waitForElement(getVisibleGeneratingBar, 'Expected visible generating bar')).not.toBeNull();
+
+    intervalCallback?.();
+
+    expect(await waitForElement(() => getVisibleReadyButton('Play'), 'Expected visible Play button')).not.toBeNull();
+    expect(lastAudio?.src.endsWith('/api/tts/audio/blog/shared-post')).toBe(true);
+    expect(clearIntervalCalls).toBeGreaterThan(0);
+  });
+
+  test('keeps showing the generating bar while a local generation request is still in flight', async () => {
+    const statuses: TtsState[] = ['not_generated', 'not_generated'];
+    let resolveGenerate: ((value: Response) => void) | null = null;
+
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) {
+        return jsonResponse({
+          status: statuses.shift() ?? 'not_generated',
+        });
+      }
+
+      if (url.endsWith('/api/tts/generate')) {
+        return new Promise<Response>((resolve) => {
+          resolveGenerate = resolve;
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer();
+
+    const listenButton = getVisibleListenButton();
+    if (!(listenButton instanceof testWindow.HTMLElement)) {
+      throw new Error('Expected visible listen button');
+    }
+
+    await act(async () => {
+      listenButton.dispatchEvent(
+        new testWindow.MouseEvent('click', { bubbles: true })
+      );
+      await flushEffects();
+    });
+
+    expect(await waitForElement(getVisibleGeneratingBar, 'Expected generating bar after clicking Listen')).not.toBeNull();
+
+    intervalCallback?.();
+
+    expect(await waitForElement(getVisibleGeneratingBar, 'Expected generating bar to stay visible while request is in flight')).not.toBeNull();
+    expect(getVisibleListenButton()).toBeNull();
+
+    resolveGenerate?.(new Response('', { status: 200 }));
+
+    expect(await waitForElement(() => getVisibleReadyButton('Pause'), 'Expected visible Pause button after generation finishes')).not.toBeNull();
+    expect(lastAudio?.src.endsWith('/api/tts/audio/blog/shared-post')).toBe(true);
+  });
+});

--- a/components/blog/TtsPlayer.test.tsx
+++ b/components/blog/TtsPlayer.test.tsx
@@ -22,6 +22,8 @@ class MockAudio {
   src = '';
   duration = 75;
   currentTime = 0;
+  paused = true;
+  playCalls = 0;
   private listeners = new Map<string, Set<(event: Event) => void>>();
 
   constructor() {
@@ -33,12 +35,20 @@ class MockAudio {
   }
 
   async play() {
+    this.playCalls += 1;
+    this.paused = false;
     this.emit('playing');
     return;
   }
 
   pause() {
+    if (this.paused) return;
+    this.paused = true;
     this.emit('pause');
+  }
+
+  dispatch(type: string) {
+    this.emit(type);
   }
 
   addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
@@ -171,6 +181,23 @@ async function waitForElement<T>(
   throw new Error(`${failureMessage}\n${container.innerHTML}`);
 }
 
+async function waitForCondition(
+  predicate: () => boolean,
+  failureMessage: string
+): Promise<void> {
+  const deadline = Date.now() + 1000;
+
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+
+    await act(async () => {
+      await flushEffects();
+    });
+  }
+
+  throw new Error(`${failureMessage}\n${container.innerHTML}`);
+}
+
 function getVisibleGeneratingBar() {
   return getAllElements(container).find(
     (element) =>
@@ -287,6 +314,7 @@ describe('TtsPlayer', () => {
 
     expect(await waitForElement(() => getVisibleReadyButton('Play'), 'Expected visible Play button')).not.toBeNull();
     expect(lastAudio?.src.endsWith('/api/tts/audio/blog/shared-post')).toBe(true);
+    expect(lastAudio?.playCalls).toBe(0);
     expect(clearIntervalCalls).toBeGreaterThan(0);
   });
 
@@ -335,5 +363,55 @@ describe('TtsPlayer', () => {
 
     expect(await waitForElement(() => getVisibleReadyButton('Pause'), 'Expected visible Pause button after generation finishes')).not.toBeNull();
     expect(lastAudio?.src.endsWith('/api/tts/audio/blog/shared-post')).toBe(true);
+    expect(lastAudio?.playCalls).toBe(1);
+  });
+
+  test('does not autoplay when audio is already ready for another viewer', async () => {
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) {
+        return jsonResponse({ status: 'ready' satisfies TtsState });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer();
+
+    expect(await waitForElement(() => getVisibleReadyButton('Play'), 'Expected Play button for remote-ready audio')).not.toBeNull();
+    expect(getVisibleReadyButton('Pause')).toBeNull();
+    expect(lastAudio?.playCalls).toBe(0);
+  });
+
+  test('renders safe time labels when audio metadata is non-finite', async () => {
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) {
+        return jsonResponse({ status: 'ready' satisfies TtsState });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer();
+
+    expect(await waitForElement(() => getVisibleReadyButton('Play'), 'Expected ready controls before timeline check')).not.toBeNull();
+
+    if (!lastAudio) {
+      throw new Error('Expected audio instance');
+    }
+
+    await act(async () => {
+      lastAudio.duration = Number.POSITIVE_INFINITY;
+      lastAudio.currentTime = Number.NaN;
+      lastAudio.dispatch('durationchange');
+      lastAudio.dispatch('timeupdate');
+      await flushEffects();
+    });
+
+    await waitForCondition(
+      () => (container.textContent ?? '').includes('0:00 / 0:00'),
+      'Expected safe fallback timeline text'
+    );
+    expect(container.textContent ?? '').not.toContain('Infinity');
+    expect(container.textContent ?? '').not.toContain('NaN');
   });
 });

--- a/components/blog/TtsPlayer.tsx
+++ b/components/blog/TtsPlayer.tsx
@@ -196,9 +196,37 @@ function extractDominantColors(imageUrl: string): Promise<ExtractedColors> {
 }
 
 function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return '0:00';
+  }
   const m = Math.floor(seconds / 60);
   const s = Math.floor(seconds % 60);
   return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function getSafeDuration(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function getSafeCurrentTime(value: number, duration: number): number {
+  if (!Number.isFinite(value) || value < 0 || duration <= 0) {
+    return 0;
+  }
+  return Math.min(value, duration);
+}
+
+function getTimelineState(audio: HTMLAudioElement) {
+  const safeDuration = getSafeDuration(audio.duration);
+  const safeCurrentTime = getSafeCurrentTime(audio.currentTime, safeDuration);
+
+  return {
+    duration: safeDuration,
+    currentTime: safeCurrentTime,
+    progress:
+      safeDuration > 0
+        ? Math.min(100, Math.max(0, (safeCurrentTime / safeDuration) * 100))
+        : 0,
+  };
 }
 
 export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
@@ -235,11 +263,26 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
     }
   }, []);
 
+  const syncTimelineFromAudio = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    const timeline = getTimelineState(audio);
+    setDuration(timeline.duration);
+    setCurrentTime(timeline.currentTime);
+    setProgress(timeline.progress);
+  }, []);
+
   const loadReadyAudio = useCallback(
     async (autoplay = false) => {
       const audio = audioRef.current;
       if (!audio) return;
 
+      if (!autoplay && !audio.paused) {
+        audio.pause();
+      }
+
+      audio.currentTime = 0;
       const currentSrc = audio.src;
       if (!currentSrc.endsWith(sharedAudioUrl)) {
         audio.src = sharedAudioUrl;
@@ -247,9 +290,10 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
       }
 
       setState('ready');
+      setDuration(0);
       setCurrentTime(0);
       setProgress(0);
-      setPlayback(autoplay ? 'playing' : 'stopped');
+      setPlayback('stopped');
 
       if (!autoplay) return;
 
@@ -330,15 +374,15 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
 
   const handlePlay = useCallback(() => {
     if (audioRef.current) {
-      audioRef.current.play();
-      setPlayback('playing');
+      audioRef.current.play().catch(() => {
+        setPlayback('stopped');
+      });
     }
   }, []);
 
   const handlePause = useCallback(() => {
     if (audioRef.current) {
       audioRef.current.pause();
-      setPlayback('paused');
     }
   }, []);
 
@@ -356,29 +400,53 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
     const audio = new Audio();
     audioRef.current = audio;
 
-    audio.addEventListener('loadedmetadata', () => {
-      setDuration(audio.duration || 0);
-    });
+    const handleLoadedMetadata = () => {
+      syncTimelineFromAudio();
+    };
 
-    audio.addEventListener('timeupdate', () => {
-      if (audio.duration) {
-        setCurrentTime(audio.currentTime);
-        setProgress((audio.currentTime / audio.duration) * 100);
-      }
-    });
+    const handleDurationChange = () => {
+      syncTimelineFromAudio();
+    };
 
-    audio.addEventListener('ended', () => {
+    const handleTimeUpdate = () => {
+      syncTimelineFromAudio();
+    };
+
+    const handlePlaying = () => {
+      setPlayback('playing');
+      syncTimelineFromAudio();
+    };
+
+    const handlePause = () => {
+      setPlayback(audio.currentTime > 0 ? 'paused' : 'stopped');
+      syncTimelineFromAudio();
+    };
+
+    const handleEnded = () => {
       setPlayback('stopped');
       setCurrentTime(0);
       setProgress(0);
-    });
+    };
+
+    audio.addEventListener('loadedmetadata', handleLoadedMetadata);
+    audio.addEventListener('durationchange', handleDurationChange);
+    audio.addEventListener('timeupdate', handleTimeUpdate);
+    audio.addEventListener('playing', handlePlaying);
+    audio.addEventListener('pause', handlePause);
+    audio.addEventListener('ended', handleEnded);
 
     return () => {
+      audio.removeEventListener('loadedmetadata', handleLoadedMetadata);
+      audio.removeEventListener('durationchange', handleDurationChange);
+      audio.removeEventListener('timeupdate', handleTimeUpdate);
+      audio.removeEventListener('playing', handlePlaying);
+      audio.removeEventListener('pause', handlePause);
+      audio.removeEventListener('ended', handleEnded);
       audio.pause();
       audio.src = '';
       stopPolling();
     };
-  }, [stopPolling]);
+  }, [stopPolling, syncTimelineFromAudio]);
 
   useEffect(() => {
     let isActive = true;

--- a/components/blog/TtsPlayer.tsx
+++ b/components/blog/TtsPlayer.tsx
@@ -6,6 +6,7 @@ import { Headphones, Play, Pause, Square } from 'lucide-react';
 
 type TtsState = 'not_generated' | 'generating' | 'ready';
 type PlaybackState = 'stopped' | 'playing' | 'paused';
+const STATUS_POLL_INTERVAL_MS = 3000;
 
 interface TtsPlayerProps {
   slug: string;
@@ -215,7 +216,8 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const objectUrlRef = useRef<string | null>(null);
+  const generateRequestInFlightRef = useRef(false);
+  const sharedAudioUrl = `/api/tts/audio/${encodeURIComponent(type)}/${encodeURIComponent(slug)}`;
 
   useEffect(() => {
     if (coverImageUrl && !colorsLoaded) {
@@ -226,27 +228,80 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
     }
   }, [coverImageUrl, colorsLoaded]);
 
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+  }, []);
+
+  const loadReadyAudio = useCallback(
+    async (autoplay = false) => {
+      const audio = audioRef.current;
+      if (!audio) return;
+
+      const currentSrc = audio.src;
+      if (!currentSrc.endsWith(sharedAudioUrl)) {
+        audio.src = sharedAudioUrl;
+        audio.load();
+      }
+
+      setState('ready');
+      setCurrentTime(0);
+      setProgress(0);
+      setPlayback(autoplay ? 'playing' : 'stopped');
+
+      if (!autoplay) return;
+
+      try {
+        await audio.play();
+      } catch {
+        setPlayback('stopped');
+      }
+    },
+    [sharedAudioUrl]
+  );
+
   const checkStatus = useCallback(async () => {
     try {
       const res = await fetch(
-        `/api/tts/status?slug=${encodeURIComponent(slug)}&type=${encodeURIComponent(type)}`
+        `/api/tts/status?slug=${encodeURIComponent(slug)}&type=${encodeURIComponent(type)}`,
+        { cache: 'no-store' }
       );
-      if (!res.ok) return;
+      if (!res.ok) return null;
       const data = await res.json();
+      if (data.status === 'generating') {
+        setState('generating');
+        return 'generating';
+      }
       if (data.status === 'ready') {
-        setState('ready');
-        if (pollingRef.current) {
-          clearInterval(pollingRef.current);
-          pollingRef.current = null;
+        stopPolling();
+        await loadReadyAudio();
+        return 'ready';
+      }
+      if (data.status === 'not_generated') {
+        if (!generateRequestInFlightRef.current) {
+          setState('not_generated');
         }
+        return 'not_generated';
       }
     } catch {
       // ignore polling errors
     }
-  }, [slug, type]);
+    return null;
+  }, [slug, type, loadReadyAudio, stopPolling]);
+
+  const startPolling = useCallback(() => {
+    if (pollingRef.current) return;
+    pollingRef.current = setInterval(() => {
+      void checkStatus();
+    }, STATUS_POLL_INTERVAL_MS);
+  }, [checkStatus]);
 
   const handleGenerate = useCallback(async () => {
     setState('generating');
+    startPolling();
+    generateRequestInFlightRef.current = true;
 
     try {
       const res = await fetch('/api/tts/generate', {
@@ -256,9 +311,6 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
       });
 
       if (res.status === 409) {
-        if (!pollingRef.current) {
-          pollingRef.current = setInterval(checkStatus, 3000);
-        }
         return;
       }
 
@@ -267,30 +319,14 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
         return;
       }
 
-      const blob = await res.blob();
-      if (objectUrlRef.current) {
-        URL.revokeObjectURL(objectUrlRef.current);
-      }
-      const url = URL.createObjectURL(blob);
-      objectUrlRef.current = url;
-
-      if (audioRef.current) {
-        audioRef.current.src = url;
-        audioRef.current.load();
-      }
-
-      setState('ready');
-      setPlayback('playing');
-
-      setTimeout(() => {
-        audioRef.current?.play().catch(() => {
-          setPlayback('stopped');
-        });
-      }, 100);
+      stopPolling();
+      await loadReadyAudio(true);
     } catch {
       setState('not_generated');
+    } finally {
+      generateRequestInFlightRef.current = false;
     }
-  }, [text, slug, type, checkStatus]);
+  }, [text, slug, type, loadReadyAudio, startPolling, stopPolling]);
 
   const handlePlay = useCallback(() => {
     if (audioRef.current) {
@@ -340,14 +376,25 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
     return () => {
       audio.pause();
       audio.src = '';
-      if (objectUrlRef.current) {
-        URL.revokeObjectURL(objectUrlRef.current);
-      }
-      if (pollingRef.current) {
-        clearInterval(pollingRef.current);
-      }
+      stopPolling();
     };
-  }, []);
+  }, [stopPolling]);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const syncInitialStatus = async () => {
+      const status = await checkStatus();
+      if (!isActive || status === 'ready') return;
+      startPolling();
+    };
+
+    void syncInitialStatus();
+
+    return () => {
+      isActive = false;
+    };
+  }, [checkStatus, startPolling]);
 
   const gradientBg = useMemo(
     () =>
@@ -375,8 +422,9 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
       <Box
         onClick={handleGenerate}
         role="button"
-        tabIndex={0}
+        tabIndex={isVisible('not_generated') ? 0 : -1}
         aria-label="Generate audio for this post"
+        aria-hidden={!isVisible('not_generated')}
         onKeyDown={(e: React.KeyboardEvent) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
@@ -435,6 +483,7 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
         }}
         role="progressbar"
         aria-label="Generating audio"
+        aria-hidden={!isVisible('generating')}
       >
         <Box
           sx={{
@@ -470,6 +519,7 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
         direction="row"
         spacing={0}
         alignItems="center"
+        aria-hidden={!isVisible('ready')}
         sx={{
           ...transitionSx,
           opacity: isVisible('ready') ? 1 : 0,

--- a/lib/blog/loader.test.ts
+++ b/lib/blog/loader.test.ts
@@ -62,6 +62,13 @@ tags: [another]
 
 # Third Post Content`);
 
+    await createTestPost('2099-12-31.md', `---
+title: Future Post
+tags: [future]
+---
+
+# Future Post Content`);
+
     // Create a post with invalid filename (should be ignored)
     await createTestPost('invalid-name.md', `---
 title: Invalid
@@ -78,7 +85,7 @@ Content`);
   test('loadAllPosts loads and sorts posts correctly', async () => {
     const posts = await loadAllPosts(testPostsDir);
 
-    // Should load 3 valid posts (ignore invalid-name.md)
+    // Should load 3 published posts and ignore invalid-name.md
     expect(posts.length).toBe(3);
 
     // Should be sorted newest first
@@ -202,6 +209,26 @@ Content`);
 
     const all = getRecentPosts(posts, 10);
     expect(all.length).toBe(3);
+  });
+
+  test('loadAllPosts hides scheduled posts by default', async () => {
+    const posts = await loadAllPosts(testPostsDir, { now: '2026-01-17T18:00:00Z' });
+
+    expect(posts.map(post => post.filename)).toEqual([
+      '2026-01-17.md',
+      '2026-01-16.md',
+      '2026-01-15.md',
+    ]);
+  });
+
+  test('loadAllPosts can include scheduled posts for direct slugs', async () => {
+    const posts = await loadAllPosts(testPostsDir, {
+      includeScheduled: true,
+      now: '2026-01-17T18:00:00Z',
+    });
+
+    expect(posts[0]?.filename).toBe('2099-12-31.md');
+    expect(posts.some(post => post.filename === '2099-12-31.md')).toBe(true);
   });
 
   test('loadAllPosts handles empty directory', async () => {

--- a/lib/blog/loader.ts
+++ b/lib/blog/loader.ts
@@ -16,6 +16,7 @@
 import { readdir, readFile, realpath } from 'node:fs/promises';
 import { join } from 'node:path';
 import { parsePost, type ParsedPost } from './parser';
+import { extractIsoDateFromBlogFilename, getPublishState } from '@/lib/content/publish';
 
 const POSTS_DIR = join(process.cwd(), 'blog/posts');
 const DEFAULT_PAGE_SIZE = 10;
@@ -29,6 +30,11 @@ export interface PaginatedPosts {
   totalCount: number;
   currentPage: number;
   totalPages: number;
+}
+
+export interface LoadAllPostsOptions {
+  includeScheduled?: boolean;
+  now?: Date | string;
 }
 
 /**
@@ -74,7 +80,10 @@ function extractDateFromFilename(filename: string): Date {
  * @param postsDir - Override posts directory (primarily for tests)
  * @returns Array of parsed posts, sorted newest to oldest
  */
-export async function loadAllPosts(postsDir: string = POSTS_DIR): Promise<ParsedPost[]> {
+export async function loadAllPosts(
+  postsDir: string = POSTS_DIR,
+  options: LoadAllPostsOptions = {}
+): Promise<ParsedPost[]> {
   try {
     // Read directory
     const files = await readdir(postsDir);
@@ -118,7 +127,7 @@ export async function loadAllPosts(postsDir: string = POSTS_DIR): Promise<Parsed
     );
     
     // Filter out failed loads and sort by date (newest first)
-    return posts
+    const sortedPosts = posts
       .filter((p): p is ParsedPost => p !== null)
       .sort((a, b) => {
         try {
@@ -130,6 +139,14 @@ export async function loadAllPosts(postsDir: string = POSTS_DIR): Promise<Parsed
           return 0; // Keep original order on error
         }
       });
+
+    if (options.includeScheduled) {
+      return sortedPosts;
+    }
+
+    return sortedPosts.filter((post) =>
+      getPublishState(extractIsoDateFromBlogFilename(post.filename), options.now).isPublished
+    );
   } catch (error) {
     // Error handling: empty directory or permissions issue
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/lib/content/publish.test.ts
+++ b/lib/content/publish.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatLongDate, getPortlandToday, getPublishState } from './publish';
+
+describe('publish helpers', () => {
+  test('computes the Portland date around midnight correctly', () => {
+    expect(getPortlandToday('2026-04-10T06:59:00Z')).toBe('2026-04-09');
+    expect(getPortlandToday('2026-04-10T07:01:00Z')).toBe('2026-04-10');
+  });
+
+  test('stays stable across the spring DST transition', () => {
+    expect(getPortlandToday('2026-03-08T09:59:00Z')).toBe('2026-03-08');
+    expect(getPortlandToday('2026-03-08T10:01:00Z')).toBe('2026-03-08');
+  });
+
+  test('treats future-dated posts as scheduled until their PT day begins', () => {
+    expect(getPublishState('2026-04-13', '2026-04-10T19:00:00Z').isScheduled).toBe(true);
+    expect(getPublishState('2026-04-13', '2026-04-13T07:01:00Z').isPublished).toBe(true);
+  });
+
+  test('formats long dates without timezone drift', () => {
+    expect(formatLongDate('2026-04-13')).toBe('April 13, 2026');
+  });
+});

--- a/lib/content/publish.ts
+++ b/lib/content/publish.ts
@@ -1,0 +1,128 @@
+const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export const PORTLAND_TIME_ZONE = 'America/Los_Angeles';
+
+export interface PublishState {
+  publishDate: string | null;
+  todayInPortland: string;
+  isPublished: boolean;
+  isScheduled: boolean;
+}
+
+function toDateParts(dateString: string): { year: number; month: number; day: number } | null {
+  const match = dateString.match(ISO_DATE_PATTERN);
+  if (!match?.[1] || !match[2] || !match[3]) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return null;
+  }
+
+  if (month < 1 || month > 12 || day < 1 || day > 31) {
+    return null;
+  }
+
+  const candidate = new Date(Date.UTC(year, month - 1, day, 12));
+  if (candidate.getUTCFullYear() !== year) return null;
+  if (candidate.getUTCMonth() !== month - 1) return null;
+  if (candidate.getUTCDate() !== day) return null;
+
+  return { year, month, day };
+}
+
+function resolveNow(now: Date | string | undefined): Date {
+  if (now instanceof Date) {
+    return Number.isNaN(now.getTime()) ? new Date() : now;
+  }
+
+  if (typeof now === 'string') {
+    const isoDate = normalizeIsoDateString(now);
+    if (isoDate) {
+      const parts = toDateParts(isoDate);
+      if (parts) {
+        return new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 12));
+      }
+    }
+
+    const parsed = new Date(now);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return new Date();
+}
+
+export function normalizeIsoDateString(value: string | undefined | null): string | null {
+  if (typeof value !== 'string') return null;
+
+  const trimmed = value.trim();
+  return toDateParts(trimmed) ? trimmed : null;
+}
+
+export function extractIsoDateFromBlogFilename(filename: string): string | null {
+  const match = filename.match(/^(\d{4}-\d{2}-\d{2})\.md$/);
+  return normalizeIsoDateString(match?.[1] ?? null);
+}
+
+export function getDateStringInTimeZone(
+  timeZone: string,
+  now?: Date | string
+): string {
+  const resolvedNow = resolveNow(now);
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+
+  const parts = formatter.formatToParts(resolvedNow);
+  const year = parts.find((part) => part.type === 'year')?.value;
+  const month = parts.find((part) => part.type === 'month')?.value;
+  const day = parts.find((part) => part.type === 'day')?.value;
+
+  if (!year || !month || !day) {
+    throw new Error(`Unable to compute date parts for timezone ${timeZone}`);
+  }
+
+  return `${year}-${month}-${day}`;
+}
+
+export function getPortlandToday(now?: Date | string): string {
+  return getDateStringInTimeZone(PORTLAND_TIME_ZONE, now);
+}
+
+export function getPublishState(
+  publishDate: string | undefined | null,
+  now?: Date | string
+): PublishState {
+  const normalizedPublishDate = normalizeIsoDateString(publishDate);
+  const todayInPortland = getPortlandToday(now);
+  const isScheduled = normalizedPublishDate !== null && normalizedPublishDate > todayInPortland;
+
+  return {
+    publishDate: normalizedPublishDate,
+    todayInPortland,
+    isPublished: !isScheduled,
+    isScheduled,
+  };
+}
+
+export function formatLongDate(dateString: string | undefined | null): string | null {
+  const parts = toDateParts(normalizeIsoDateString(dateString) ?? '');
+  if (!parts) return null;
+
+  const date = new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 12));
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'UTC',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(date);
+}

--- a/lib/lore/loader.test.ts
+++ b/lib/lore/loader.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { getLorePostBySlug, loadAllLorePosts } from './loader';
+
+let testRootDir = '';
+let testPostsDir = '';
+
+async function createLorePost(filename: string, content: string) {
+  await mkdir(testPostsDir, { recursive: true });
+  await writeFile(join(testPostsDir, filename), content, 'utf-8');
+}
+
+describe('Lore Loader', () => {
+  beforeAll(async () => {
+    testRootDir = await mkdtemp(join(tmpdir(), 'website-lore-posts-'));
+    testPostsDir = join(testRootDir, 'lore', 'posts');
+
+    if (testPostsDir.startsWith(process.cwd())) {
+      throw new Error(`Refusing to run tests using real working directory: ${testPostsDir}`);
+    }
+
+    await rm(testPostsDir, { recursive: true, force: true });
+    await mkdir(testPostsDir, { recursive: true });
+
+    await createLorePost('first-lore.md', `---
+title: First Lore
+date: 2026-01-15
+tags: [lore, arc]
+---
+
+# First Lore`);
+
+    await createLorePost('second-lore.md', `---
+title: Second Lore
+date: 2026-01-16
+tags: [lore]
+---
+
+# Second Lore`);
+
+    await createLorePost('future-lore.md', `---
+title: Future Lore
+date: 2099-12-31
+tags: [lore, future]
+---
+
+# Future Lore`);
+
+    await createLorePost('undated-lore.md', `---
+title: Undated Lore
+tags: [lore]
+---
+
+# Undated Lore`);
+
+    await createLorePost('invalid file!.md', `---
+title: Invalid Lore
+---
+
+# Invalid`);
+  });
+
+  afterAll(async () => {
+    if (testRootDir) {
+      await rm(testRootDir, { recursive: true, force: true });
+    }
+  });
+
+  test('loadAllLorePosts hides future-dated lore by default', async () => {
+    const posts = await loadAllLorePosts({ now: '2026-01-16T18:00:00Z' }, testPostsDir);
+
+    expect(posts.map(post => post.filename)).toContain('second-lore.md');
+    expect(posts.map(post => post.filename)).toContain('first-lore.md');
+    expect(posts.map(post => post.filename)).toContain('undated-lore.md');
+    expect(posts.map(post => post.filename)).not.toContain('future-lore.md');
+  });
+
+  test('loadAllLorePosts can include scheduled lore for direct routes', async () => {
+    const posts = await loadAllLorePosts(
+      {
+        includeScheduled: true,
+        now: '2026-01-16T18:00:00Z',
+      },
+      testPostsDir
+    );
+
+    expect(posts[0]?.filename).toBe('future-lore.md');
+    expect(getLorePostBySlug(posts, 'future-lore')?.metadata.title).toBe('Future Lore');
+  });
+});

--- a/lib/lore/loader.ts
+++ b/lib/lore/loader.ts
@@ -9,6 +9,7 @@ import { readdir, readFile, realpath, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { parsePost, type ParsedPost } from '@/lib/blog/parser';
+import { getPublishState } from '@/lib/content/publish';
 
 const POSTS_DIR = join(process.cwd(), 'lore/posts');
 const DEFAULT_PAGE_SIZE = 10;
@@ -19,6 +20,11 @@ export interface PaginatedLorePosts {
   totalCount: number;
   currentPage: number;
   totalPages: number;
+}
+
+export interface LoadAllLorePostsOptions {
+  includeScheduled?: boolean;
+  now?: Date | string;
 }
 
 function isValidFilename(filename: string): boolean {
@@ -51,22 +57,25 @@ function parseYYYYMMDDToUtcMs(dateString: string | undefined): number | null {
   return ms;
 }
 
-export async function loadAllLorePosts(): Promise<ParsedPost[]> {
+export async function loadAllLorePosts(
+  options: LoadAllLorePostsOptions = {},
+  postsDir: string = POSTS_DIR
+): Promise<ParsedPost[]> {
   try {
-    const files = await readdir(POSTS_DIR);
+    const files = await readdir(postsDir);
     const mdFiles = files.filter(f => isValidFilename(f));
 
     if (mdFiles.length === 0) {
-      console.info('No valid markdown files found in lore/posts/');
+      console.info(`No valid markdown files found in ${postsDir}`);
       return [];
     }
 
-    const realPostsDir = await realpath(POSTS_DIR);
+    const realPostsDir = await realpath(postsDir);
 
     const posts = await Promise.all(
       mdFiles.map(async (filename) => {
         try {
-          const filepath = join(POSTS_DIR, filename);
+          const filepath = join(postsDir, filename);
           const realFilePath = await realpath(filepath);
           if (!realFilePath.startsWith(realPostsDir)) {
             console.error(`Security: Path traversal attempt detected for ${filename}`);
@@ -75,6 +84,7 @@ export async function loadAllLorePosts(): Promise<ParsedPost[]> {
 
           const content = await readFile(filepath, 'utf-8');
           const parsed = parsePost(filename, content);
+          const explicitPublishDate = parsed.metadata.date;
 
           // Ensure lore posts have a stable date for SSR/CSR consistency (prevents hydration mismatch).
           if (!parsed.metadata.date) {
@@ -82,7 +92,10 @@ export async function loadAllLorePosts(): Promise<ParsedPost[]> {
             parsed.metadata.date = fileStat.mtime.toISOString().slice(0, 10);
           }
 
-          return parsed;
+          return {
+            parsed,
+            explicitPublishDate,
+          };
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
           console.error(`Error loading ${filename}:`, errorMessage);
@@ -91,23 +104,36 @@ export async function loadAllLorePosts(): Promise<ParsedPost[]> {
       })
     );
 
-    const parsedPosts = posts.filter((p): p is ParsedPost => p !== null);
+    const parsedPosts = posts.filter(
+      (
+        post
+      ): post is {
+        parsed: ParsedPost;
+        explicitPublishDate: string | undefined;
+      } => post !== null
+    );
 
     // Sort newest -> oldest by displayed date (expected YYYY-MM-DD).
     // Invalid/missing dates sort last. Tie-break by filename for stability.
     parsedPosts.sort((a, b) => {
-      const dateA = parseYYYYMMDDToUtcMs(a.metadata.date);
-      const dateB = parseYYYYMMDDToUtcMs(b.metadata.date);
+      const dateA = parseYYYYMMDDToUtcMs(a.parsed.metadata.date);
+      const dateB = parseYYYYMMDDToUtcMs(b.parsed.metadata.date);
 
-      if (dateA === null && dateB === null) return a.filename.localeCompare(b.filename);
+      if (dateA === null && dateB === null) return a.parsed.filename.localeCompare(b.parsed.filename);
       if (dateA === null) return 1;
       if (dateB === null) return -1;
 
       if (dateA !== dateB) return dateB - dateA;
-      return a.filename.localeCompare(b.filename);
+      return a.parsed.filename.localeCompare(b.parsed.filename);
     });
 
-    return parsedPosts;
+    if (options.includeScheduled) {
+      return parsedPosts.map((post) => post.parsed);
+    }
+
+    return parsedPosts.filter((post) =>
+      getPublishState(post.explicitPublishDate, options.now).isPublished
+    ).map((post) => post.parsed);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     console.error('Error loading lore posts:', errorMessage);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^25.0.9",
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",
+    "happy-dom": "^20.9.0",
     "tsx": "^4.21.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

This branch adds publish-date gating for blog and lore content using Portland time, keeps scheduled posts routable by direct slug with a teaser view instead of full content, and hardens the on-page TTS experience for shared generation and remote playback.

## What changed

### Portland publish scheduling for blog and lore

- Added shared publish-date utilities in `lib/content/publish.ts` to:
  - normalize ISO dates safely,
  - compute the current calendar date in `America/Los_Angeles`,
  - determine whether a post is already published or still scheduled,
  - format long dates without timezone drift.
- Updated the blog loader to filter future-dated posts out of normal listing flows by default while still allowing scheduled posts to be loaded explicitly for direct slug routes.
- Updated the lore loader with the same scheduled-content behavior, using explicit frontmatter dates for publish visibility while still preserving the existing date fallback for stable display behavior.

### Scheduled post teaser behavior

- Updated direct blog and lore post pages to include scheduled posts when resolving slugs, then compute whether the requested entry is still scheduled.
- Extended `PostView` so scheduled posts render a teaser state instead of full content:
  - cover art stays visible but heavily blurred,
  - full markdown content is hidden,
  - the TTS player is hidden,
  - the page shows a “Scheduled for …” message using the stable publish date.
- Updated scheduled blog metadata so future-dated posts present themselves as scheduled instead of looking fully published.

### Shared TTS generation state

- Updated `TtsPlayer` so TTS status is checked on mount rather than only after a local click.
- If another viewer has already started generation for the same post, the player now immediately shows the generating bar and keeps polling until the shared audio is ready.
- The initiating viewer still gets autoplay after generation completes, but other viewers now transition to a ready player in a stopped state instead of unexpectedly auto-playing.

### TTS metadata and playback fixes

- Hardened the player timeline logic so it never renders `Infinity` or `NaN` in the elapsed/duration UI.
- Moved playback-state transitions closer to actual audio events so the visible controls stay aligned with the real player state.
- Fixed the Next.js `/api/tts/audio/[type]/[slug]` proxy to preserve byte-range behavior and upstream audio metadata by:
  - forwarding incoming `Range` headers,
  - returning the upstream stream body directly,
  - preserving partial-content responses and range metadata.
- This resolves the remote-ready playback issue where valid WAV files were being proxied back as chunked `200 OK` responses, which prevented the browser from resolving finite audio duration reliably.

## Testing

- Added `lib/content/publish.test.ts` covering:
  - Portland date calculation near midnight,
  - DST stability,
  - scheduled-vs-published state transitions,
  - long-date formatting without timezone drift.
- Extended `lib/blog/loader.test.ts` to verify scheduled blog posts are hidden by default and can still be included for direct routes.
- Added `lib/lore/loader.test.ts` covering the same scheduled-content behavior for lore posts.
- Added `components/blog/PostView.test.tsx` to verify scheduled previews hide the body and show teaser copy.
- Added `components/blog/TtsPlayer.test.tsx` using `happy-dom` to cover:
  - shared generating-state visibility,
  - generating-to-ready transitions,
  - no autoplay for remote-ready viewers,
  - local autoplay for the initiating viewer,
  - safe fallback timeline rendering for non-finite metadata.

## Verification performed

- `bun test lib/content/publish.test.ts lib/blog/loader.test.ts lib/lore/loader.test.ts components/blog/PostView.test.tsx`
- `bun test components/blog/TtsPlayer.test.tsx components/blog/PostView.test.tsx lib/content/publish.test.ts`
- `bun run build`
- Manual header verification of the TTS proxy confirmed `206 Partial Content`, `Accept-Ranges`, `Content-Length`, and `Content-Range` are now preserved through the Next route.

## Notes for reviewers

- `loadAllPosts()` and `loadAllLorePosts()` now accept options that allow scheduled content to be included intentionally for direct-route rendering while keeping normal listing behavior filtered.
- `happy-dom` was added as a dev dependency to support DOM-backed regression tests for the TTS player state machine.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
