### PR TITLE
Fix website radio looping by hardening stream recovery

### DIFF
--- a/.agents/setup-agents.sh
+++ b/.agents/setup-agents.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if ! command -v yay >/dev/null 2>&1; then
-  exit 1
-fi
-
 if ! command -v bun >/dev/null 2>&1; then
-  exit 1
+  yay -Syu --noconfirm --needed bun
 fi
 
 PLAYWRIGHT_SYSTEM_PACKAGES=(

--- a/.agents/setup-agents.sh
+++ b/.agents/setup-agents.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v yay >/dev/null 2>&1; then
+  exit 1
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  exit 1
+fi
+
+PLAYWRIGHT_SYSTEM_PACKAGES=(
+  nspr
+  nss
+  atk
+  at-spi2-core
+  libxcomposite
+)
+
+yay -Syu --noconfirm --needed "${PLAYWRIGHT_SYSTEM_PACKAGES[@]}"
+
+bun install
+
+bunx playwright install chromium
+
+PLAYWRIGHT_CHROME="$(find "${HOME}/.cache/ms-playwright" -type f -path '*/chrome-linux64/chrome' | sort | tail -n 1)"
+
+if [[ -z "${PLAYWRIGHT_CHROME}" ]]; then
+  exit 1
+fi
+
+sudo mkdir -p /opt/google/chrome
+sudo ln -sf "${PLAYWRIGHT_CHROME}" /opt/google/chrome/chrome
+
+if [[ "${MIDORI_AI_AGENTS_RUNNER_INTERACTIVE:-false}" == "true" ]]; then
+  DEV_LOG="/tmp/workspace-dev.log"
+
+  if ss -ltn 2>/dev/null | grep -q ':3000 '; then
+    exit 0
+  else
+    nohup bun run dev >"${DEV_LOG}" 2>&1 &
+  fi
+fi

--- a/app/api/radio/stream/route.ts
+++ b/app/api/radio/stream/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { normalizeChannel, normalizeQuality } from '@/lib/radio/contract';
+
+export const runtime = 'nodejs';
+
+const RADIO_BASE_URL = 'https://radio.midori-ai.xyz';
+
+export async function GET(request: NextRequest) {
+  try {
+    const rawChannel = request.nextUrl.searchParams.get('channel');
+    const rawQuality = request.nextUrl.searchParams.get('q');
+    const upstreamUrl = new URL('/radio/v1/stream', RADIO_BASE_URL);
+
+    upstreamUrl.searchParams.set('channel', normalizeChannel(rawChannel));
+    upstreamUrl.searchParams.set('q', normalizeQuality(rawQuality));
+
+    const cacheBust = request.nextUrl.searchParams.get('ts');
+    if (cacheBust !== null && cacheBust.trim().length > 0) {
+      upstreamUrl.searchParams.set('ts', cacheBust);
+    }
+
+    const upstream = await fetch(upstreamUrl, {
+      cache: 'no-store',
+      headers: {
+        Accept: 'audio/mpeg, audio/*;q=0.9, */*;q=0.8',
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+      },
+    });
+
+    if (upstream.body === null) {
+      return NextResponse.json(
+        {
+          version: 'radio.v1',
+          ok: false,
+          now: new Date().toISOString(),
+          data: null,
+          error: {
+            code: 'UPSTREAM_EMPTY_STREAM',
+            message: 'Radio stream response did not include a body.',
+          },
+        },
+        {
+          status: 502,
+          headers: {
+            'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+          },
+        }
+      );
+    }
+
+    return new NextResponse(upstream.body, {
+      status: upstream.status,
+      headers: {
+        'Content-Type': upstream.headers.get('content-type') ?? 'audio/mpeg',
+        'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+        Pragma: 'no-cache',
+        Expires: '0',
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown upstream error';
+
+    return NextResponse.json(
+      {
+        version: 'radio.v1',
+        ok: false,
+        now: new Date().toISOString(),
+        data: null,
+        error: {
+          code: 'UPSTREAM_UNREACHABLE',
+          message,
+        },
+      },
+      {
+        status: 502,
+        headers: {
+          'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+        },
+      }
+    );
+  }
+}

--- a/components/radio/RadioWidget.test.tsx
+++ b/components/radio/RadioWidget.test.tsx
@@ -1,0 +1,447 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Window } from 'happy-dom';
+
+import RadioWidget from './RadioWidget';
+
+let testWindow: Window;
+let container: HTMLDivElement;
+let root: Root;
+let currentTrackId = 'track-1';
+let lastAudio: MockAudio | null = null;
+let intervalEntries = new Map<number, { delay: number; callback: () => void }>();
+let timeoutEntries = new Map<number, { delay: number; callback: () => void }>();
+let nextTimerId = 1;
+
+const originalGlobals = new Map<string, unknown>();
+const originalSetTimeout = globalThis.setTimeout;
+const originalClearTimeout = globalThis.clearTimeout;
+const originalSetInterval = globalThis.setInterval;
+const originalClearInterval = globalThis.clearInterval;
+
+class MockAudio {
+  src = '';
+  volume = 0.5;
+  paused = true;
+  playCalls = 0;
+  srcHistory: string[] = [];
+  private listeners = new Map<string, Set<(event: Event) => void>>();
+
+  constructor() {
+    lastAudio = this;
+  }
+
+  load() {
+    return;
+  }
+
+  async play() {
+    this.playCalls += 1;
+    this.paused = false;
+    this.srcHistory.push(this.src);
+    this.emit('playing');
+    return;
+  }
+
+  pause() {
+    if (this.paused) {
+      return;
+    }
+
+    this.paused = true;
+    this.emit('pause');
+  }
+
+  removeAttribute(name: string) {
+    if (name === 'src') {
+      this.src = '';
+    }
+  }
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    const listeners = this.listeners.get(type) ?? new Set<(event: Event) => void>();
+    const normalized =
+      typeof listener === 'function'
+        ? listener
+        : (event: Event) => listener.handleEvent(event);
+    listeners.add(normalized);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    const listeners = this.listeners.get(type);
+    if (!listeners) {
+      return;
+    }
+
+    for (const current of listeners) {
+      if (current === listener || (typeof listener !== 'function' && current === listener.handleEvent)) {
+        listeners.delete(current);
+      }
+    }
+  }
+
+  private emit(type: string) {
+    const event = new Event(type);
+    const listeners = this.listeners.get(type);
+    if (!listeners) {
+      return;
+    }
+
+    for (const listener of listeners) {
+      listener(event);
+    }
+  }
+}
+
+class MockImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  set src(_value: string) {
+    originalSetTimeout(() => {
+      this.onload?.();
+    }, 0);
+  }
+}
+
+function installDom() {
+  testWindow = new Window({ url: 'http://localhost:3000' });
+
+  const assignments: Record<string, unknown> = {
+    window: testWindow,
+    document: testWindow.document,
+    navigator: testWindow.navigator,
+    Node: testWindow.Node,
+    Text: testWindow.Text,
+    HTMLElement: testWindow.HTMLElement,
+    HTMLDivElement: testWindow.HTMLDivElement,
+    Event: testWindow.Event,
+    MouseEvent: testWindow.MouseEvent,
+    KeyboardEvent: testWindow.KeyboardEvent,
+    MutationObserver: testWindow.MutationObserver,
+    SyntaxError,
+    ResizeObserver: class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+    Image: MockImage,
+    Audio: MockAudio,
+    getComputedStyle: testWindow.getComputedStyle.bind(testWindow),
+    requestAnimationFrame: (cb: FrameRequestCallback) => originalSetTimeout(() => cb(Date.now()), 0),
+    cancelAnimationFrame: (id: number) => originalClearTimeout(id),
+    IS_REACT_ACT_ENVIRONMENT: true,
+  };
+
+  for (const [key, value] of Object.entries(assignments)) {
+    originalGlobals.set(key, (globalThis as Record<string, unknown>)[key]);
+    (globalThis as Record<string, unknown>)[key] = value;
+  }
+
+  const matchMedia = ((query: string) => ({
+    matches:
+      query === '(hover: hover)' ||
+      query === '(pointer: fine)' ||
+      query === '(min-width: 1024px)',
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as typeof testWindow.matchMedia;
+
+  testWindow.matchMedia = matchMedia;
+  testWindow.scrollTo = () => {};
+  (testWindow as Window & { SyntaxError?: typeof SyntaxError }).SyntaxError = SyntaxError;
+}
+
+function installTimers() {
+  intervalEntries = new Map();
+  timeoutEntries = new Map();
+  nextTimerId = 1;
+
+  const setIntervalMock = ((handler: TimerHandler, delay?: number) => {
+    const id = nextTimerId += 1;
+    if (typeof handler === 'function') {
+      intervalEntries.set(id, {
+        delay: delay ?? 0,
+        callback: handler as () => void,
+      });
+    }
+    return id as ReturnType<typeof setInterval>;
+  }) as typeof setInterval;
+
+  const clearIntervalMock = ((id: ReturnType<typeof setInterval>) => {
+    intervalEntries.delete(Number(id));
+  }) as typeof clearInterval;
+
+  const setTimeoutMock = ((handler: TimerHandler, delay?: number) => {
+    if ((delay ?? 0) <= 0) {
+      return originalSetTimeout(handler, delay);
+    }
+
+    const id = nextTimerId += 1;
+    if (typeof handler === 'function') {
+      timeoutEntries.set(id, {
+        delay: delay ?? 0,
+        callback: handler as () => void,
+      });
+    }
+    return id as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+
+  const clearTimeoutMock = ((id: ReturnType<typeof setTimeout>) => {
+    if (timeoutEntries.delete(Number(id))) {
+      return;
+    }
+    originalClearTimeout(id);
+  }) as typeof clearTimeout;
+
+  globalThis.setInterval = setIntervalMock;
+  globalThis.clearInterval = clearIntervalMock;
+  globalThis.setTimeout = setTimeoutMock;
+  globalThis.clearTimeout = clearTimeoutMock;
+  testWindow.setInterval = setIntervalMock;
+  testWindow.clearInterval = clearIntervalMock;
+  testWindow.setTimeout = setTimeoutMock;
+  testWindow.clearTimeout = clearTimeoutMock;
+}
+
+function restoreDom() {
+  for (const [key, value] of originalGlobals.entries()) {
+    if (value === undefined) {
+      delete (globalThis as Record<string, unknown>)[key];
+      continue;
+    }
+    (globalThis as Record<string, unknown>)[key] = value;
+  }
+
+  originalGlobals.clear();
+  globalThis.setTimeout = originalSetTimeout;
+  globalThis.clearTimeout = originalClearTimeout;
+  globalThis.setInterval = originalSetInterval;
+  globalThis.clearInterval = originalClearInterval;
+}
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function setFetchMock() {
+  originalGlobals.set('fetch', globalThis.fetch);
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+
+    if (url.endsWith('/api/radio-images')) {
+      return jsonResponse({
+        images: ['/blog/a.png'],
+        placeholder: '/blog/placeholder.png',
+        count: 1,
+        generated_at: '2026-04-17T00:00:00.000Z',
+      });
+    }
+
+    if (url.endsWith('/api/radio/channels')) {
+      return jsonResponse({
+        version: 'radio.v1',
+        ok: true,
+        now: '2026-04-17T00:00:00.000Z',
+        data: {
+          channels: [{ name: 'all', track_count: 10 }],
+        },
+        error: null,
+      });
+    }
+
+    if (url.includes('/api/radio/current')) {
+      return jsonResponse({
+        version: 'radio.v1',
+        ok: true,
+        now: '2026-04-17T00:00:00.000Z',
+        data: {
+          station_label: 'Midori AI Radio',
+          channel: 'all',
+          track_id: currentTrackId,
+          title: currentTrackId === 'track-1' ? 'Track One' : 'Track Two',
+          duration_ms: 180000,
+          position_ms: 1000,
+          started_at: '2026-04-17T00:00:00.000Z',
+          warmup_active: false,
+          quality_levels: [],
+        },
+        error: null,
+      });
+    }
+
+    if (url.includes('/api/radio/art')) {
+      return jsonResponse({
+        version: 'radio.v1',
+        ok: true,
+        now: '2026-04-17T00:00:00.000Z',
+        data: {
+          channel: 'all',
+          track_id: currentTrackId,
+          has_art: false,
+          mime: null,
+          art_url: '',
+        },
+        error: null,
+      });
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as typeof fetch;
+}
+
+async function flushEffects() {
+  await Promise.resolve();
+  await new Promise((resolve) => originalSetTimeout(resolve, 0));
+  await Promise.resolve();
+  await new Promise((resolve) => originalSetTimeout(resolve, 0));
+}
+
+async function renderWidget() {
+  await act(async () => {
+    root.render(<RadioWidget />);
+    await flushEffects();
+  });
+}
+
+async function waitForCondition(predicate: () => boolean, failureMessage: string) {
+  const deadline = Date.now() + 1500;
+
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+
+    await act(async () => {
+      await flushEffects();
+    });
+  }
+
+  throw new Error(`${failureMessage}\n${container.innerHTML}`);
+}
+
+function getPrimaryButton() {
+  return container.querySelector('button');
+}
+
+async function clickPrimaryButton() {
+  const button = getPrimaryButton();
+  if (!(button instanceof testWindow.HTMLButtonElement)) {
+    throw new Error(`Expected primary button.\n${container.innerHTML}`);
+  }
+
+  await act(async () => {
+    button.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+    await flushEffects();
+  });
+}
+
+async function runInterval(delay: number) {
+  const match = [...intervalEntries.values()].find((entry) => entry.delay === delay);
+  if (!match) {
+    throw new Error(`Expected interval with delay ${delay}`);
+  }
+
+  await act(async () => {
+    match.callback();
+    await flushEffects();
+  });
+}
+
+async function runTimeout(delay: number) {
+  const match = [...timeoutEntries.entries()].find(([, entry]) => entry.delay === delay);
+  if (!match) {
+    throw new Error(`Expected timeout with delay ${delay}`);
+  }
+
+  timeoutEntries.delete(match[0]);
+
+  await act(async () => {
+    match[1].callback();
+    await flushEffects();
+  });
+}
+
+beforeEach(() => {
+  installDom();
+  installTimers();
+  setFetchMock();
+  currentTrackId = 'track-1';
+  lastAudio = null;
+
+  testWindow.localStorage.setItem('midoriai.radio.open', 'true');
+
+  container = testWindow.document.createElement('div');
+  testWindow.document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+    await flushEffects();
+  });
+
+  container.remove();
+  restoreDom();
+});
+
+describe('RadioWidget', () => {
+  test('reconnects with a fresh stream URL when the track changes', async () => {
+    await renderWidget();
+    await clickPrimaryButton();
+
+    await waitForCondition(
+      () => lastAudio !== null && lastAudio.playCalls === 1,
+      'Expected initial playback to start'
+    );
+
+    const firstSrc = lastAudio?.src ?? '';
+    expect(firstSrc).toContain('/api/radio/stream');
+    expect(firstSrc).toContain('channel=all');
+    expect(firstSrc).toContain('q=medium');
+    expect(firstSrc).toContain('ts=');
+
+    currentTrackId = 'track-2';
+    await runInterval(5000);
+
+    await waitForCondition(
+      () => lastAudio !== null && lastAudio.playCalls === 2,
+      'Expected playback to reconnect for the new track'
+    );
+
+    expect(lastAudio?.src).not.toBe(firstSrc);
+    expect(lastAudio?.src).toContain('ts=');
+  });
+
+  test('rotates the live session when the max session timer expires', async () => {
+    await renderWidget();
+    await clickPrimaryButton();
+
+    await waitForCondition(
+      () => lastAudio !== null && lastAudio.playCalls === 1,
+      'Expected initial playback to start'
+    );
+
+    const firstSrc = lastAudio?.src ?? '';
+
+    await runTimeout(2 * 60 * 60 * 1000);
+
+    await waitForCondition(
+      () => lastAudio !== null && lastAudio.playCalls === 2,
+      'Expected playback to reconnect after the session timer'
+    );
+
+    expect(lastAudio?.src).not.toBe(firstSrc);
+  });
+});

--- a/components/radio/RadioWidget.tsx
+++ b/components/radio/RadioWidget.tsx
@@ -34,6 +34,7 @@ import {
 const PLACEHOLDER_IMAGE = '/blog/placeholder.png';
 const RETRY_DELAYS_MS = [1000, 2000, 4000, 8000, 16000, 30000] as const;
 const HOVER_CLOSE_LINGER_MS = 3000;
+const MAX_STREAM_SESSION_MS = 2 * 60 * 60 * 1000;
 const COLLAPSED_SIZE_PX = 56;
 const EXPANDED_WIDTH_PX = 380;
 const EXPANDED_HEIGHT_PX = 336;
@@ -117,6 +118,7 @@ export default function RadioWidget() {
   const desktopEligible = useDesktopEligibility();
   const audioRef = React.useRef<HTMLAudioElement | null>(null);
   const retryTimerRef = React.useRef<number | null>(null);
+  const sessionRefreshTimerRef = React.useRef<number | null>(null);
   const closeLingerTimerRef = React.useRef<number | null>(null);
   const reconnectInFlightRef = React.useRef(false);
   const retryAttemptRef = React.useRef(0);
@@ -126,6 +128,8 @@ export default function RadioWidget() {
   const channelRef = React.useRef('all');
   const metadataRequestRef = React.useRef(0);
   const initializedChannelRef = React.useRef(false);
+  const currentTrackIdRef = React.useRef<string | null>(null);
+  const observedTrackIdRef = React.useRef<string | null>(null);
 
   const [hydrated, setHydrated] = React.useState(false);
   const [hovered, setHovered] = React.useState(false);
@@ -158,6 +162,11 @@ export default function RadioWidget() {
   React.useEffect(() => {
     playbackDesiredRef.current = playbackDesired;
   }, [playbackDesired]);
+
+  React.useEffect(() => {
+    const normalizedTrackId = currentTrack?.track_id?.trim();
+    currentTrackIdRef.current = normalizedTrackId && normalizedTrackId.length > 0 ? normalizedTrackId : null;
+  }, [currentTrack?.track_id]);
 
   React.useEffect(() => {
     const restored = loadRadioState();
@@ -210,6 +219,13 @@ export default function RadioWidget() {
     if (retryTimerRef.current !== null) {
       window.clearTimeout(retryTimerRef.current);
       retryTimerRef.current = null;
+    }
+  }, []);
+
+  const clearSessionRefreshTimer = React.useCallback(() => {
+    if (sessionRefreshTimerRef.current !== null) {
+      window.clearTimeout(sessionRefreshTimerRef.current);
+      sessionRefreshTimerRef.current = null;
     }
   }, []);
 
@@ -281,6 +297,7 @@ export default function RadioWidget() {
     }
 
     reconnectInFlightRef.current = true;
+    clearSessionRefreshTimer();
     const attempt = retryAttemptRef.current;
     setStreamState(attempt === 0 ? 'connecting' : 'retrying');
     setStatusText(attempt === 0 ? 'Connecting…' : 'Reconnecting…');
@@ -289,6 +306,9 @@ export default function RadioWidget() {
       const streamUrl = buildStreamUrl({
         channel: channelRef.current,
         quality: qualityRef.current,
+        baseUrl: window.location.origin,
+        path: '/api/radio/stream',
+        cacheBust: true,
       });
 
       audio.pause();
@@ -309,17 +329,46 @@ export default function RadioWidget() {
     } finally {
       reconnectInFlightRef.current = false;
     }
-  }, [scheduleRetry]);
+  }, [clearSessionRefreshTimer, scheduleRetry]);
 
   React.useEffect(() => {
     reconnectRef.current = reconnectStream;
   }, [reconnectStream]);
+
+  const refreshLiveSession = React.useCallback(
+    (statusMessage: string) => {
+      if (!playbackDesiredRef.current) {
+        return;
+      }
+
+      clearRetryTimer();
+      clearSessionRefreshTimer();
+      retryAttemptRef.current = 0;
+      setStatusText(statusMessage);
+      void reconnectRef.current();
+    },
+    [clearRetryTimer, clearSessionRefreshTimer]
+  );
+
+  const scheduleSessionRefresh = React.useCallback(() => {
+    if (!playbackDesiredRef.current) {
+      return;
+    }
+
+    clearSessionRefreshTimer();
+    sessionRefreshTimerRef.current = window.setTimeout(() => {
+      sessionRefreshTimerRef.current = null;
+      refreshLiveSession('Refreshing live session…');
+    }, MAX_STREAM_SESSION_MS);
+  }, [clearSessionRefreshTimer, refreshLiveSession]);
 
   const stopPlayback = React.useCallback(() => {
     setPlaybackDesired(false);
     playbackDesiredRef.current = false;
     retryAttemptRef.current = 0;
     clearRetryTimer();
+    clearSessionRefreshTimer();
+    observedTrackIdRef.current = currentTrackIdRef.current;
 
     const audio = audioRef.current;
     if (audio !== null) {
@@ -331,15 +380,17 @@ export default function RadioWidget() {
 
     setStreamState('idle');
     setStatusText('Stopped');
-  }, [clearRetryTimer]);
+  }, [clearRetryTimer, clearSessionRefreshTimer]);
 
   const startPlayback = React.useCallback(() => {
     setPlaybackDesired(true);
     playbackDesiredRef.current = true;
     retryAttemptRef.current = 0;
     clearRetryTimer();
+    clearSessionRefreshTimer();
+    observedTrackIdRef.current = currentTrackIdRef.current;
     void reconnectRef.current();
-  }, [clearRetryTimer]);
+  }, [clearRetryTimer, clearSessionRefreshTimer]);
 
   React.useEffect(() => {
     const audio = new Audio();
@@ -349,11 +400,14 @@ export default function RadioWidget() {
 
     const handlePlaying = () => {
       clearRetryTimer();
+      clearSessionRefreshTimer();
       retryAttemptRef.current = 0;
+      observedTrackIdRef.current = currentTrackIdRef.current;
       setStreamState('playing');
       setStatusText('Live');
       setLastError(null);
       clearRadioLastError();
+      scheduleSessionRefresh();
     };
 
     const handlePause = () => {
@@ -367,6 +421,7 @@ export default function RadioWidget() {
         return;
       }
 
+      clearSessionRefreshTimer();
       scheduleRetry('Stream interrupted.');
     };
 
@@ -378,6 +433,7 @@ export default function RadioWidget() {
 
     return () => {
       clearRetryTimer();
+      clearSessionRefreshTimer();
       audio.pause();
       audio.removeAttribute('src');
       audio.load();
@@ -388,13 +444,14 @@ export default function RadioWidget() {
       audio.removeEventListener('ended', handleError);
       audioRef.current = null;
     };
-  }, [clearRetryTimer, scheduleRetry]);
+  }, [clearRetryTimer, clearSessionRefreshTimer, scheduleRetry, scheduleSessionRefresh]);
 
   React.useEffect(() => {
     return () => {
       clearCloseLingerTimer();
+      clearSessionRefreshTimer();
     };
-  }, [clearCloseLingerTimer]);
+  }, [clearCloseLingerTimer, clearSessionRefreshTimer]);
 
   React.useEffect(() => {
     if (stickyOpen) {
@@ -534,9 +591,34 @@ export default function RadioWidget() {
 
     clearRetryTimer();
     retryAttemptRef.current = 0;
-    setStatusText('Switching channel…');
-    void reconnectRef.current();
-  }, [channel, refreshMetadata, clearRetryTimer, hydrated]);
+    observedTrackIdRef.current = null;
+    refreshLiveSession('Switching channel…');
+  }, [channel, refreshMetadata, clearRetryTimer, hydrated, refreshLiveSession]);
+
+  React.useEffect(() => {
+    const trackId = currentTrackIdRef.current;
+
+    if (!playbackDesired) {
+      observedTrackIdRef.current = trackId;
+      return;
+    }
+
+    if (trackId === null) {
+      return;
+    }
+
+    if (observedTrackIdRef.current === null) {
+      observedTrackIdRef.current = trackId;
+      return;
+    }
+
+    if (observedTrackIdRef.current === trackId) {
+      return;
+    }
+
+    observedTrackIdRef.current = trackId;
+    refreshLiveSession('Refreshing stream for the next track…');
+  }, [currentTrack?.track_id, playbackDesired, refreshLiveSession]);
 
   const fallbackIdentity = `${currentTrack?.title ?? 'unknown'}::${currentTrack?.track_id ?? 'unknown'}`;
   const fallbackImage = React.useMemo(() => {

--- a/lib/radio/client.test.ts
+++ b/lib/radio/client.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildStreamUrl } from './client';
+
+describe('buildStreamUrl', () => {
+  test('builds a stream URL with normalized channel and quality', () => {
+    const url = new URL(
+      buildStreamUrl({
+        channel: '  ALL ',
+        quality: 'HIGH',
+      })
+    );
+
+    expect(url.pathname).toBe('/radio/v1/stream');
+    expect(url.searchParams.get('channel')).toBe('all');
+    expect(url.searchParams.get('q')).toBe('high');
+  });
+
+  test('supports a custom stream path and cache-busting token', () => {
+    const url = new URL(
+      buildStreamUrl({
+        channel: 'lofi',
+        quality: 'medium',
+        baseUrl: 'http://localhost:3000',
+        path: '/api/radio/stream',
+        cacheBust: true,
+      })
+    );
+
+    expect(url.origin).toBe('http://localhost:3000');
+    expect(url.pathname).toBe('/api/radio/stream');
+    expect(url.searchParams.get('channel')).toBe('lofi');
+    expect(url.searchParams.get('q')).toBe('medium');
+    expect(url.searchParams.get('ts')).toBeTruthy();
+  });
+
+  test('produces a fresh cache-busting token for each reconnect URL', () => {
+    const first = new URL(
+      buildStreamUrl({
+        channel: 'all',
+        quality: 'medium',
+        cacheBust: true,
+      })
+    );
+    const second = new URL(
+      buildStreamUrl({
+        channel: 'all',
+        quality: 'medium',
+        cacheBust: true,
+      })
+    );
+
+    expect(first.searchParams.get('ts')).toBeTruthy();
+    expect(second.searchParams.get('ts')).toBeTruthy();
+    expect(first.searchParams.get('ts')).not.toBe(second.searchParams.get('ts'));
+  });
+});

--- a/lib/radio/client.ts
+++ b/lib/radio/client.ts
@@ -20,6 +20,14 @@ const JSON_HEADERS = {
   Accept: 'application/json',
 } as const;
 
+function createCacheBustToken(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.round(Math.random() * 1_000_000_000)}`;
+}
+
 export class RadioApiError extends Error {
   code: string;
   status: number;
@@ -157,16 +165,17 @@ export function buildStreamUrl(options: {
   channel: string | null | undefined;
   quality: QualityName | string | null | undefined;
   baseUrl?: string;
+  path?: string;
   cacheBust?: boolean;
 }): string {
   const normalizedChannel = normalizeChannel(options.channel);
   const normalizedQuality = normalizeQuality(options.quality);
-  const url = new URL('/radio/v1/stream', options.baseUrl ?? MIDORIAI_RADIO_BASE_URL);
+  const url = new URL(options.path ?? '/radio/v1/stream', options.baseUrl ?? MIDORIAI_RADIO_BASE_URL);
   url.searchParams.set('channel', normalizedChannel);
   url.searchParams.set('q', normalizedQuality);
 
   if (options.cacheBust === true) {
-    url.searchParams.set('ts', Date.now().toString());
+    url.searchParams.set('ts', createCacheBustToken());
   }
 
   return url.toString();


### PR DESCRIPTION
## Summary

This PR hardens the website radio player against the looping/stale-stream behavior that was showing up on the blog site.

Previously, the website widget held onto a long-lived browser `Audio` stream and only reset it on explicit stop, channel changes, or hard media errors. That made the website especially vulnerable to cases where playback got into a bad state without the browser surfacing a clean failure. The result was a stream that could appear to keep playing while effectively getting stuck.

This change moves the website toward a more self-healing model:

- stream connections now go through a same-origin website proxy route instead of pointing the browser directly at the upstream radio stream
- each connect/reconnect gets a fresh cache-busting token so the website stops reusing a stale stream URL
- the radio widget now reconnects automatically when a track change is observed during playback
- retry reconnects also get fresh stream URLs
- active playback sessions now rotate on a long watchdog window of **2 hours**

The goal here is to keep the website from getting pinned to a bad stream session while still preserving the current user-facing playback flow.

## What Changed

### Added a same-origin radio stream proxy

A new `app/api/radio/stream` route proxies the upstream `radio.midori-ai.xyz` stream with explicit no-store / no-cache headers.

That route:

- normalizes `channel` and `q`
- passes through the cache-busting `ts` token
- requests the upstream stream with no-cache headers
- returns the audio body with `Cache-Control: no-store, no-cache, must-revalidate, private`
- returns structured `radio.v1` JSON errors if the upstream stream is missing or unreachable

This gives the website a cleaner boundary for browser playback and avoids depending on the browser to manage a shared external stream URL correctly.

### Hardened the radio widget reconnect lifecycle

`components/radio/RadioWidget.tsx` now tracks more stream lifecycle state and uses that state to recover automatically instead of waiting indefinitely for a hard failure.

Key widget behavior changes:

- playback now connects to `/api/radio/stream`
- each playback attempt uses a fresh cache-busted stream URL
- the widget tracks the current observed track id while polling metadata
- if the track changes while playback is active, the widget forces a reconnect so the stream session stays aligned with current metadata
- the widget maintains a session refresh timer and rotates the stream after **2 hours**
- reconnect/session timers are cleared on stop, unmount, and reconnect boundaries

The retry/backoff behavior remains in place, but reconnects are now more deliberate and less likely to keep a bad session alive forever.

### Expanded automated coverage

This PR also adds focused test coverage for the new behavior:

- `lib/radio/client.test.ts`
  - verifies normalized stream URL generation
  - verifies custom path support for same-origin stream routing
  - verifies cache-busting tokens are fresh across reconnect URLs

- `components/radio/RadioWidget.test.tsx`
  - verifies the widget reconnects with a fresh stream URL when the polled track changes
  - verifies the long-lived session watchdog triggers a reconnect on the 2-hour window

## Why This Helps

The other radio clients were reported to behave normally, which pointed the issue back at the website-specific playback lifecycle rather than the radio service as a whole.

The website was the only place in this stack that:

- depended on a browser `Audio` element
- kept one long-lived stream URL alive for extended periods
- relied on browser media events to decide when recovery was needed

By forcing fresh stream sessions at controlled points, this PR reduces the chance that the website gets trapped in a stale or partially broken playback state that never escalates into a clean error.

## Testing

Passed:

- `bun test`
- `bun test lib/radio/client.test.ts components/radio/RadioWidget.test.tsx`
- `bun run build`

Manual/browser validation was also performed against the dev server:

- confirmed desktop radio widget renders and expands correctly
- confirmed the website requests `GET /api/radio/stream?channel=all&q=medium&ts=<token>`
- confirmed same-origin radio metadata endpoints continue returning `200`
- confirmed the radio play button still has a visible focus outline on desktop

Validation artifacts were written under `/tmp/agents-artifacts/`.

## Notes

- The watchdog window was intentionally set to **2 hours** instead of the earlier shorter rotation window.
- During viewport validation, an unrelated existing horizontal overflow was still present on smaller home-page viewports. The desktop-only radio widget was hidden there, so that issue does not appear to come from this radio change.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
