### PR TITLE
feat: stream TTS chunks for early playback + clearer status

### DIFF
--- a/app/api/tts/chunk/[type]/[slug]/[index]/route.ts
+++ b/app/api/tts/chunk/[type]/[slug]/[index]/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const TTS_BASE = 'http://127.0.0.1:8888';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ type: string; slug: string; index: string }> }
+) {
+  try {
+    const { type, slug, index } = await params;
+
+    if (!['blog', 'lore'].includes(type)) {
+      return NextResponse.json({ error: 'Invalid type' }, { status: 400 });
+    }
+
+    const parsedIndex = Number(index);
+    if (!Number.isInteger(parsedIndex) || parsedIndex < 0) {
+      return NextResponse.json(
+        { error: 'Invalid chunk index, expected non-negative integer' },
+        { status: 400 }
+      );
+    }
+
+    const upstream = await fetch(
+      `${TTS_BASE}/chunk/${encodeURIComponent(type)}/${encodeURIComponent(slug)}/${parsedIndex}`,
+      { cache: 'no-store' }
+    );
+
+    if (!upstream.ok) {
+      const detail = await upstream.text();
+      const message = detail || 'Chunk unavailable';
+      return NextResponse.json(
+        { error: 'Chunk unavailable', detail: message },
+        { status: upstream.status }
+      );
+    }
+
+    const responseHeaders = new Headers(upstream.headers);
+    responseHeaders.set('Cache-Control', 'no-store');
+    responseHeaders.set(
+      'Content-Disposition',
+      `inline; filename="${slug}-${String(parsedIndex).padStart(4, '0')}.wav"`
+    );
+
+    return new NextResponse(upstream.body, {
+      status: upstream.status,
+      headers: responseHeaders,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown upstream error';
+    return NextResponse.json(
+      { error: 'TTS service unavailable', detail: message },
+      { status: 502 }
+    );
+  }
+}

--- a/app/api/tts/generate/route.ts
+++ b/app/api/tts/generate/route.ts
@@ -32,31 +32,17 @@ export async function POST(request: NextRequest) {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text, slug, type }),
+      cache: 'no-store',
     });
 
-    if (upstream.status === 409) {
-      return NextResponse.json(
-        { error: 'Audio is already being generated for this post' },
-        { status: 409 }
-      );
-    }
+    const upstreamBody = await upstream.text();
+    const contentType = upstream.headers.get('content-type') ?? 'application/json';
 
-    if (!upstream.ok) {
-      const err = await upstream.text();
-      return NextResponse.json(
-        { error: 'TTS generation failed', detail: err },
-        { status: upstream.status }
-      );
-    }
-
-    const audioBuffer = await upstream.arrayBuffer();
-
-    return new NextResponse(audioBuffer, {
-      status: 200,
+    return new NextResponse(upstreamBody, {
+      status: upstream.status,
       headers: {
-        'Content-Type': 'audio/wav',
-        'Cache-Control': 'public, max-age=86400',
-        'Content-Disposition': `inline; filename="${slug}.wav"`,
+        'Content-Type': contentType,
+        'Cache-Control': 'no-store',
       },
     });
   } catch (error) {

--- a/app/api/tts/status/route.ts
+++ b/app/api/tts/status/route.ts
@@ -39,6 +39,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       {
         status: 'not_generated',
+        generated_chunks: 0,
+        total_chunks: 0,
+        playable: false,
         error: 'TTS service unavailable',
         detail: message,
       },

--- a/components/blog/TtsPlayer.test.tsx
+++ b/components/blog/TtsPlayer.test.tsx
@@ -7,16 +7,26 @@ import { TtsPlayer } from './TtsPlayer';
 
 type TtsState = 'not_generated' | 'generating' | 'ready';
 
+interface StatusPayload {
+  status: TtsState;
+  generated_chunks?: number;
+  total_chunks?: number;
+  playable?: boolean;
+}
+
 let testWindow: Window;
 let container: HTMLDivElement;
 let root: Root;
 let lastAudio: MockAudio | null = null;
 let intervalCallback: (() => void) | null = null;
 let clearIntervalCalls = 0;
+let blobCounter = 0;
 
 const originalGlobals = new Map<string, unknown>();
 const originalSetInterval = globalThis.setInterval;
 const originalClearInterval = globalThis.clearInterval;
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
 
 class MockAudio {
   src = '';
@@ -66,7 +76,10 @@ class MockAudio {
     if (!listeners) return;
 
     for (const current of listeners) {
-      if (current === listener || (typeof listener !== 'function' && current === listener.handleEvent)) {
+      if (
+        current === listener ||
+        (typeof listener !== 'function' && current === listener.handleEvent)
+      ) {
         listeners.delete(current);
       }
     }
@@ -100,8 +113,7 @@ function installDom() {
     MutationObserver: testWindow.MutationObserver,
     SyntaxError,
     getComputedStyle: testWindow.getComputedStyle.bind(testWindow),
-    requestAnimationFrame: (cb: FrameRequestCallback) =>
-      setTimeout(() => cb(Date.now()), 0),
+    requestAnimationFrame: (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 0),
     cancelAnimationFrame: (id: number) => clearTimeout(id),
     Audio: MockAudio,
     IS_REACT_ACT_ENVIRONMENT: true,
@@ -123,6 +135,12 @@ function installDom() {
     dispatchEvent: () => false,
   })) as typeof testWindow.matchMedia;
   testWindow.scrollTo = () => {};
+
+  URL.createObjectURL = (() => {
+    blobCounter += 1;
+    return `blob:mock-${blobCounter}`;
+  }) as typeof URL.createObjectURL;
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL;
 }
 
 function restoreDom() {
@@ -136,14 +154,24 @@ function restoreDom() {
   originalGlobals.clear();
 }
 
-function jsonResponse(body: unknown) {
+function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
-    status: 200,
+    status,
     headers: { 'Content-Type': 'application/json' },
   });
 }
 
-function setFetchMock(handler: (url: string, init?: RequestInit) => Promise<Response> | Response) {
+function wavResponse() {
+  const bytes = new Uint8Array([1, 2, 3, 4]);
+  return new Response(bytes, {
+    status: 200,
+    headers: { 'Content-Type': 'audio/wav' },
+  });
+}
+
+function setFetchMock(
+  handler: (url: string, init?: RequestInit) => Promise<Response> | Response
+) {
   originalGlobals.set('fetch', globalThis.fetch);
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) =>
     handler(String(input), init)) as typeof fetch;
@@ -167,7 +195,7 @@ async function waitForElement<T>(
   getter: () => T | null,
   failureMessage: string
 ): Promise<T> {
-  const deadline = Date.now() + 1000;
+  const deadline = Date.now() + 1200;
 
   while (Date.now() < deadline) {
     const element = getter();
@@ -185,7 +213,7 @@ async function waitForCondition(
   predicate: () => boolean,
   failureMessage: string
 ): Promise<void> {
-  const deadline = Date.now() + 1000;
+  const deadline = Date.now() + 1200;
 
   while (Date.now() < deadline) {
     if (predicate()) return;
@@ -199,20 +227,24 @@ async function waitForCondition(
 }
 
 function getVisibleGeneratingBar() {
-  return getAllElements(container).find(
-    (element) =>
-      element.getAttribute('role') === 'progressbar' &&
-      element.getAttribute('aria-hidden') === 'false'
-  ) ?? null;
+  return (
+    getAllElements(container).find(
+      (element) =>
+        element.getAttribute('role') === 'progressbar' &&
+        element.getAttribute('aria-hidden') === 'false'
+    ) ?? null
+  );
 }
 
 function getVisibleListenButton() {
-  return getAllElements(container).find(
-    (element) =>
-      element.getAttribute('role') === 'button' &&
-      element.getAttribute('aria-label') === 'Generate audio for this post' &&
-      element.getAttribute('aria-hidden') === 'false'
-  ) ?? null;
+  return (
+    getAllElements(container).find(
+      (element) =>
+        element.getAttribute('role') === 'button' &&
+        element.getAttribute('aria-label') === 'Generate audio for this post' &&
+        element.getAttribute('aria-hidden') === 'false'
+    ) ?? null
+  );
 }
 
 function getVisibleReadyButton(label: 'Play' | 'Pause') {
@@ -221,11 +253,13 @@ function getVisibleReadyButton(label: 'Play' | 'Pause') {
   );
   if (!activeContainer) return null;
 
-  return getAllElements(activeContainer).find(
-    (element) =>
-      element.tagName.toLowerCase() === 'button' &&
-      element.getAttribute('aria-label') === label
-  ) ?? null;
+  return (
+    getAllElements(activeContainer).find(
+      (element) =>
+        element.tagName.toLowerCase() === 'button' &&
+        element.getAttribute('aria-label') === label
+    ) ?? null
+  );
 }
 
 function getAllElements(rootElement: Element) {
@@ -245,19 +279,29 @@ function getAllElements(rootElement: Element) {
   return elements;
 }
 
+function payload(status: TtsState, partial?: Omit<StatusPayload, 'status'>): StatusPayload {
+  return {
+    status,
+    generated_chunks: 0,
+    total_chunks: 0,
+    playable: false,
+    ...partial,
+  };
+}
+
 beforeEach(() => {
   installDom();
   lastAudio = null;
   intervalCallback = null;
   clearIntervalCalls = 0;
+  blobCounter = 0;
 
   container = testWindow.document.createElement('div');
   testWindow.document.body.appendChild(container);
   root = createRoot(container);
 
   globalThis.setInterval = ((handler: TimerHandler) => {
-    intervalCallback =
-      typeof handler === 'function' ? (handler as () => void) : null;
+    intervalCallback = typeof handler === 'function' ? (handler as () => void) : null;
     return 1 as unknown as ReturnType<typeof setInterval>;
   }) as typeof setInterval;
 
@@ -276,15 +320,16 @@ afterEach(async () => {
   restoreDom();
   globalThis.setInterval = originalSetInterval;
   globalThis.clearInterval = originalClearInterval;
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
 });
 
 describe('TtsPlayer', () => {
   test('shows the generating bar immediately when another visitor already started generation', async () => {
     setFetchMock(async (url) => {
       if (url.includes('/api/tts/status')) {
-        return jsonResponse({ status: 'generating' satisfies TtsState });
+        return jsonResponse(payload('generating', { generated_chunks: 1, total_chunks: 8 }));
       }
-
       throw new Error(`Unexpected fetch: ${url}`);
     });
 
@@ -294,13 +339,51 @@ describe('TtsPlayer', () => {
   });
 
   test('transitions from generating to ready when polling sees completed audio', async () => {
-    const statuses: TtsState[] = ['generating', 'ready'];
+    const statuses: StatusPayload[] = [
+      payload('generating', { generated_chunks: 2, total_chunks: 8 }),
+      payload('ready', { generated_chunks: 8, total_chunks: 8, playable: true }),
+    ];
 
     setFetchMock(async (url) => {
       if (url.includes('/api/tts/status')) {
-        return jsonResponse({
-          status: statuses.shift() ?? 'ready',
-        });
+        return jsonResponse(statuses.shift() ?? payload('ready'));
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer();
+
+    expect(await waitForElement(getVisibleGeneratingBar, 'Expected visible generating bar')).not
+      .toBeNull();
+
+    intervalCallback?.();
+
+    expect(await waitForElement(() => getVisibleReadyButton('Play'), 'Expected visible Play button'))
+      .not.toBeNull();
+    expect(lastAudio?.src.endsWith('/api/tts/audio/blog/shared-post')).toBe(true);
+    expect(lastAudio?.playCalls).toBe(0);
+    expect(clearIntervalCalls).toBeGreaterThan(0);
+  });
+
+  test('starts streaming playback after listen when generation is playable', async () => {
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) {
+        return jsonResponse(payload('not_generated'));
+      }
+
+      if (url.endsWith('/api/tts/generate')) {
+        return jsonResponse(
+          payload('generating', {
+            generated_chunks: 3,
+            total_chunks: 12,
+            playable: true,
+          }),
+          202
+        );
+      }
+
+      if (url.includes('/api/tts/chunk/blog/shared-post/0')) {
+        return wavResponse();
       }
 
       throw new Error(`Unexpected fetch: ${url}`);
@@ -308,25 +391,30 @@ describe('TtsPlayer', () => {
 
     await renderPlayer();
 
-    expect(await waitForElement(getVisibleGeneratingBar, 'Expected visible generating bar')).not.toBeNull();
+    const listenButton = getVisibleListenButton();
+    if (!(listenButton instanceof testWindow.HTMLElement)) {
+      throw new Error('Expected visible listen button');
+    }
 
-    intervalCallback?.();
+    await act(async () => {
+      listenButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
 
-    expect(await waitForElement(() => getVisibleReadyButton('Play'), 'Expected visible Play button')).not.toBeNull();
-    expect(lastAudio?.src.endsWith('/api/tts/audio/blog/shared-post')).toBe(true);
-    expect(lastAudio?.playCalls).toBe(0);
-    expect(clearIntervalCalls).toBeGreaterThan(0);
+    expect(await waitForElement(() => getVisibleReadyButton('Pause'), 'Expected Pause button')).not
+      .toBeNull();
+    expect(lastAudio?.src.startsWith('blob:mock-')).toBe(true);
+    expect(lastAudio?.playCalls).toBeGreaterThan(0);
+    expect(container.textContent ?? '').toContain('Generating...');
   });
 
-  test('keeps showing the generating bar while a local generation request is still in flight', async () => {
-    const statuses: TtsState[] = ['not_generated', 'not_generated'];
+  test('keeps showing generating bar while local generate request is in flight and not yet playable', async () => {
+    const statuses: StatusPayload[] = [payload('not_generated'), payload('not_generated')];
     let resolveGenerate: ((value: Response) => void) | null = null;
 
     setFetchMock(async (url) => {
       if (url.includes('/api/tts/status')) {
-        return jsonResponse({
-          status: statuses.shift() ?? 'not_generated',
-        });
+        return jsonResponse(statuses.shift() ?? payload('not_generated'));
       }
 
       if (url.endsWith('/api/tts/generate')) {
@@ -346,38 +434,45 @@ describe('TtsPlayer', () => {
     }
 
     await act(async () => {
-      listenButton.dispatchEvent(
-        new testWindow.MouseEvent('click', { bubbles: true })
-      );
+      listenButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
       await flushEffects();
     });
 
-    expect(await waitForElement(getVisibleGeneratingBar, 'Expected generating bar after clicking Listen')).not.toBeNull();
+    expect(await waitForElement(getVisibleGeneratingBar, 'Expected generating bar')).not.toBeNull();
 
     intervalCallback?.();
 
-    expect(await waitForElement(getVisibleGeneratingBar, 'Expected generating bar to stay visible while request is in flight')).not.toBeNull();
-    expect(getVisibleListenButton()).toBeNull();
+    expect(await waitForElement(getVisibleGeneratingBar, 'Expected generating bar to remain visible'))
+      .not.toBeNull();
+    expect(getVisibleReadyButton('Play')).toBeNull();
 
-    resolveGenerate?.(new Response('', { status: 200 }));
-
-    expect(await waitForElement(() => getVisibleReadyButton('Pause'), 'Expected visible Pause button after generation finishes')).not.toBeNull();
-    expect(lastAudio?.src.endsWith('/api/tts/audio/blog/shared-post')).toBe(true);
-    expect(lastAudio?.playCalls).toBe(1);
+    await act(async () => {
+      resolveGenerate?.(
+        jsonResponse(
+          payload('generating', {
+            generated_chunks: 1,
+            total_chunks: 10,
+            playable: false,
+          }),
+          202
+        )
+      );
+      await flushEffects();
+    });
   });
 
   test('does not autoplay when audio is already ready for another viewer', async () => {
     setFetchMock(async (url) => {
       if (url.includes('/api/tts/status')) {
-        return jsonResponse({ status: 'ready' satisfies TtsState });
+        return jsonResponse(payload('ready', { generated_chunks: 6, total_chunks: 6, playable: true }));
       }
-
       throw new Error(`Unexpected fetch: ${url}`);
     });
 
     await renderPlayer();
 
-    expect(await waitForElement(() => getVisibleReadyButton('Play'), 'Expected Play button for remote-ready audio')).not.toBeNull();
+    expect(await waitForElement(() => getVisibleReadyButton('Play'), 'Expected Play button')).not
+      .toBeNull();
     expect(getVisibleReadyButton('Pause')).toBeNull();
     expect(lastAudio?.playCalls).toBe(0);
   });
@@ -385,15 +480,15 @@ describe('TtsPlayer', () => {
   test('renders safe time labels when audio metadata is non-finite', async () => {
     setFetchMock(async (url) => {
       if (url.includes('/api/tts/status')) {
-        return jsonResponse({ status: 'ready' satisfies TtsState });
+        return jsonResponse(payload('ready', { generated_chunks: 6, total_chunks: 6, playable: true }));
       }
-
       throw new Error(`Unexpected fetch: ${url}`);
     });
 
     await renderPlayer();
 
-    expect(await waitForElement(() => getVisibleReadyButton('Play'), 'Expected ready controls before timeline check')).not.toBeNull();
+    expect(await waitForElement(() => getVisibleReadyButton('Play'), 'Expected ready controls')).not
+      .toBeNull();
 
     if (!lastAudio) {
       throw new Error('Expected audio instance');

--- a/components/blog/TtsPlayer.tsx
+++ b/components/blog/TtsPlayer.tsx
@@ -2,11 +2,15 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, IconButton, Stack, Typography } from '@mui/joy';
-import { Headphones, Play, Pause, Square } from 'lucide-react';
+import { Headphones, Pause, Play, Square } from 'lucide-react';
 
 type TtsState = 'not_generated' | 'generating' | 'ready';
 type PlaybackState = 'stopped' | 'playing' | 'paused';
+type StatusSource = 'poll' | 'generate' | 'init';
+
 const STATUS_POLL_INTERVAL_MS = 3000;
+const CHUNK_RETRY_DELAY_MS = 800;
+const MIN_PLAYABLE_CHUNKS = 3;
 
 interface TtsPlayerProps {
   slug: string;
@@ -19,6 +23,44 @@ interface ExtractedColors {
   primary: string;
   secondary: string;
   tertiary: string;
+}
+
+interface TtsStatusPayload {
+  status: TtsState;
+  generated_chunks: number;
+  total_chunks: number;
+  playable: boolean;
+}
+
+function parseStatusPayload(raw: unknown): TtsStatusPayload | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const value = raw as Record<string, unknown>;
+  const status = value.status;
+  if (status !== 'not_generated' && status !== 'generating' && status !== 'ready') {
+    return null;
+  }
+
+  const parsedGenerated = Number(value.generated_chunks ?? 0);
+  const parsedTotal = Number(value.total_chunks ?? 0);
+  const totalChunks =
+    Number.isFinite(parsedTotal) && parsedTotal > 0 ? Math.floor(parsedTotal) : 0;
+  const generatedChunks =
+    Number.isFinite(parsedGenerated) && parsedGenerated > 0
+      ? Math.floor(parsedGenerated)
+      : 0;
+  const boundedGenerated =
+    totalChunks > 0 ? Math.min(generatedChunks, totalChunks) : generatedChunks;
+  const playable =
+    status === 'ready'
+      ? true
+      : Boolean(value.playable ?? boundedGenerated >= MIN_PLAYABLE_CHUNKS);
+
+  return {
+    status,
+    generated_chunks: boundedGenerated,
+    total_chunks: totalChunks,
+    playable,
+  };
 }
 
 function hexToRgb(hex: string): [number, number, number] {
@@ -44,10 +86,14 @@ function rgbToHex(r: number, g: number, b: number): string {
 }
 
 function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
-  const rn = r / 255, gn = g / 255, bn = b / 255;
-  const max = Math.max(rn, gn, bn), min = Math.min(rn, gn, bn);
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
   const l = (max + min) / 2;
-  let h = 0, s = 0;
+  let h = 0;
+  let s = 0;
 
   if (max !== min) {
     const d = max - min;
@@ -97,9 +143,7 @@ function colorDistance(
   a: [number, number, number],
   b: [number, number, number]
 ): number {
-  return (
-    (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2
-  );
+  return (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2;
 }
 
 function extractDominantColors(imageUrl: string): Promise<ExtractedColors> {
@@ -132,7 +176,10 @@ function extractDominantColors(imageUrl: string): Promise<ExtractedColors> {
         const pixels = imageData.data;
 
         const quantize = (v: number) => Math.round(v / 32) * 32;
-        const colorMap = new Map<string, { count: number; r: number; g: number; b: number }>();
+        const colorMap = new Map<
+          string,
+          { count: number; r: number; g: number; b: number }
+        >();
 
         for (let i = 0; i < pixels.length; i += 4) {
           const r = quantize(pixels[i] ?? 0);
@@ -152,10 +199,7 @@ function extractDominantColors(imageUrl: string): Promise<ExtractedColors> {
           }
         }
 
-        const sorted = Array.from(colorMap.values()).sort(
-          (a, b) => b.count - a.count
-        );
-
+        const sorted = Array.from(colorMap.values()).sort((a, b) => b.count - a.count);
         if (sorted.length === 0) {
           resolve(fallback);
           return;
@@ -171,9 +215,7 @@ function extractDominantColors(imageUrl: string): Promise<ExtractedColors> {
               colorDistance([p.r, p.g, p.b], [candidate.r, candidate.g, candidate.b]) <
               minDist
           );
-          if (!tooClose) {
-            picked.push(candidate);
-          }
+          if (!tooClose) picked.push(candidate);
         }
 
         while (picked.length < 3) {
@@ -182,7 +224,9 @@ function extractDominantColors(imageUrl: string): Promise<ExtractedColors> {
 
         resolve({
           primary: ensureMinLuminance(rgbToHex(picked[0]!.r, picked[0]!.g, picked[0]!.b)),
-          secondary: ensureMinLuminance(rgbToHex(picked[1]!.r, picked[1]!.g, picked[1]!.b)),
+          secondary: ensureMinLuminance(
+            rgbToHex(picked[1]!.r, picked[1]!.g, picked[1]!.b)
+          ),
           tertiary: ensureMinLuminance(rgbToHex(picked[2]!.r, picked[2]!.g, picked[2]!.b)),
         });
       } catch {
@@ -196,9 +240,7 @@ function extractDominantColors(imageUrl: string): Promise<ExtractedColors> {
 }
 
 function formatTime(seconds: number): string {
-  if (!Number.isFinite(seconds) || seconds < 0) {
-    return '0:00';
-  }
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00';
   const m = Math.floor(seconds / 60);
   const s = Math.floor(seconds % 60);
   return `${m}:${s.toString().padStart(2, '0')}`;
@@ -209,16 +251,13 @@ function getSafeDuration(value: number): number {
 }
 
 function getSafeCurrentTime(value: number, duration: number): number {
-  if (!Number.isFinite(value) || value < 0 || duration <= 0) {
-    return 0;
-  }
+  if (!Number.isFinite(value) || value < 0 || duration <= 0) return 0;
   return Math.min(value, duration);
 }
 
 function getTimelineState(audio: HTMLAudioElement) {
   const safeDuration = getSafeDuration(audio.duration);
   const safeCurrentTime = getSafeCurrentTime(audio.currentTime, safeDuration);
-
   return {
     duration: safeDuration,
     currentTime: safeCurrentTime,
@@ -235,6 +274,8 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
   const [progress, setProgress] = useState(0);
   const [duration, setDuration] = useState(0);
   const [currentTime, setCurrentTime] = useState(0);
+  const [isGenerationActive, setIsGenerationActive] = useState(false);
+  const [canSeek, setCanSeek] = useState(false);
   const [colors, setColors] = useState<ExtractedColors>({
     primary: ensureMinLuminance('#8b5cf6'),
     secondary: ensureMinLuminance('#a78bfa'),
@@ -244,8 +285,29 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const currentChunkObjectUrlRef = useRef<string | null>(null);
+
   const generateRequestInFlightRef = useRef(false);
+  const generationRequestedRef = useRef(false);
+  const generationCompleteRef = useRef(false);
+  const playbackRef = useRef<PlaybackState>('stopped');
+
+  const streamingActiveRef = useRef(false);
+  const streamingShouldPlayRef = useRef(false);
+  const currentChunkIndexRef = useRef<number | null>(null);
+  const nextChunkIndexRef = useRef(0);
+  const generatedChunksRef = useRef(0);
+  const totalChunksRef = useRef(0);
+  const streamingOffsetRef = useRef(0);
+  const chunkDurationsRef = useRef<Map<number, number>>(new Map());
+
   const sharedAudioUrl = `/api/tts/audio/${encodeURIComponent(type)}/${encodeURIComponent(slug)}`;
+  const sharedChunkBaseUrl = `/api/tts/chunk/${encodeURIComponent(type)}/${encodeURIComponent(slug)}`;
+
+  useEffect(() => {
+    playbackRef.current = playback;
+  }, [playback]);
 
   useEffect(() => {
     if (coverImageUrl && !colorsLoaded) {
@@ -263,20 +325,80 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
     }
   }, []);
 
+  const clearChunkRetry = useCallback(() => {
+    if (retryTimeoutRef.current) {
+      clearTimeout(retryTimeoutRef.current);
+      retryTimeoutRef.current = null;
+    }
+  }, []);
+
+  const revokeCurrentChunkUrl = useCallback(() => {
+    const objectUrl = currentChunkObjectUrlRef.current;
+    if (!objectUrl) return;
+    URL.revokeObjectURL(objectUrl);
+    currentChunkObjectUrlRef.current = null;
+  }, []);
+
+  const sumKnownChunkDurations = useCallback((exclusiveEnd: number) => {
+    let total = 0;
+    for (let i = 0; i < exclusiveEnd; i++) {
+      total += chunkDurationsRef.current.get(i) ?? 0;
+    }
+    return total;
+  }, []);
+
   const syncTimelineFromAudio = useCallback(() => {
     const audio = audioRef.current;
     if (!audio) return;
 
-    const timeline = getTimelineState(audio);
-    setDuration(timeline.duration);
-    setCurrentTime(timeline.currentTime);
-    setProgress(timeline.progress);
-  }, []);
+    if (!streamingActiveRef.current) {
+      const timeline = getTimelineState(audio);
+      setDuration(timeline.duration);
+      setCurrentTime(timeline.currentTime);
+      setProgress(timeline.progress);
+      return;
+    }
+
+    const activeIndex = currentChunkIndexRef.current;
+    const baseOffset =
+      activeIndex !== null
+        ? sumKnownChunkDurations(activeIndex)
+        : streamingOffsetRef.current;
+
+    const chunkDuration = getSafeDuration(audio.duration);
+    const chunkCurrent = getSafeCurrentTime(audio.currentTime, chunkDuration);
+    const totalCurrent = baseOffset + chunkCurrent;
+    const generatedDuration = sumKnownChunkDurations(generatedChunksRef.current);
+    const totalDuration = Math.max(totalCurrent, generatedDuration);
+    const nextProgress =
+      totalDuration > 0
+        ? Math.min(100, Math.max(0, (totalCurrent / totalDuration) * 100))
+        : 0;
+
+    setDuration(totalDuration);
+    setCurrentTime(totalCurrent);
+    setProgress(nextProgress);
+  }, [sumKnownChunkDurations]);
 
   const loadReadyAudio = useCallback(
     async (autoplay = false) => {
       const audio = audioRef.current;
       if (!audio) return;
+
+      clearChunkRetry();
+      revokeCurrentChunkUrl();
+      streamingActiveRef.current = false;
+      streamingShouldPlayRef.current = false;
+      currentChunkIndexRef.current = null;
+      nextChunkIndexRef.current = 0;
+      chunkDurationsRef.current.clear();
+      streamingOffsetRef.current = 0;
+      setCanSeek(true);
+      setState('ready');
+      setPlayback('stopped');
+      setDuration(0);
+      setCurrentTime(0);
+      setProgress(0);
 
       if (!autoplay && !audio.paused) {
         audio.pause();
@@ -289,122 +411,326 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
         audio.load();
       }
 
-      setState('ready');
-      setDuration(0);
-      setCurrentTime(0);
-      setProgress(0);
-      setPlayback('stopped');
-
       if (!autoplay) return;
-
       try {
         await audio.play();
       } catch {
         setPlayback('stopped');
       }
     },
-    [sharedAudioUrl]
+    [clearChunkRetry, revokeCurrentChunkUrl, sharedAudioUrl]
   );
 
-  const checkStatus = useCallback(async () => {
-    try {
-      const res = await fetch(
-        `/api/tts/status?slug=${encodeURIComponent(slug)}&type=${encodeURIComponent(type)}`,
-        { cache: 'no-store' }
-      );
-      if (!res.ok) return null;
-      const data = await res.json();
-      if (data.status === 'generating') {
-        setState('generating');
-        return 'generating';
+  const tryStartChunkPlayback = useCallback(
+    async (chunkIndex: number, autoplay: boolean): Promise<boolean> => {
+      const audio = audioRef.current;
+      if (!audio || !streamingActiveRef.current) return false;
+
+      if (
+        generationCompleteRef.current &&
+        totalChunksRef.current > 0 &&
+        chunkIndex >= totalChunksRef.current
+      ) {
+        return false;
       }
-      if (data.status === 'ready') {
+
+      if (generatedChunksRef.current <= chunkIndex) {
+        if (autoplay && streamingShouldPlayRef.current) {
+          clearChunkRetry();
+          retryTimeoutRef.current = setTimeout(() => {
+            void tryStartChunkPlayback(chunkIndex, true);
+          }, CHUNK_RETRY_DELAY_MS);
+        }
+        return false;
+      }
+
+      try {
+        const response = await fetch(`${sharedChunkBaseUrl}/${chunkIndex}`, {
+          cache: 'no-store',
+        });
+        if (!response.ok) {
+          if (
+            (response.status === 404 || response.status === 425) &&
+            autoplay &&
+            streamingShouldPlayRef.current
+          ) {
+            clearChunkRetry();
+            retryTimeoutRef.current = setTimeout(() => {
+              void tryStartChunkPlayback(chunkIndex, true);
+            }, CHUNK_RETRY_DELAY_MS);
+          }
+          return false;
+        }
+
+        const blob = await response.blob();
+        const objectUrl = URL.createObjectURL(blob);
+        revokeCurrentChunkUrl();
+        currentChunkObjectUrlRef.current = objectUrl;
+
+        currentChunkIndexRef.current = chunkIndex;
+        nextChunkIndexRef.current = chunkIndex + 1;
+        streamingOffsetRef.current = sumKnownChunkDurations(chunkIndex);
+
+        audio.src = objectUrl;
+        audio.currentTime = 0;
+        audio.load();
+        syncTimelineFromAudio();
+
+        if (!autoplay || !streamingShouldPlayRef.current) return true;
+        try {
+          await audio.play();
+          return true;
+        } catch {
+          setPlayback('stopped');
+          return false;
+        }
+      } catch {
+        if (autoplay && streamingShouldPlayRef.current) {
+          clearChunkRetry();
+          retryTimeoutRef.current = setTimeout(() => {
+            void tryStartChunkPlayback(chunkIndex, true);
+          }, CHUNK_RETRY_DELAY_MS);
+        }
+        return false;
+      }
+    },
+    [
+      clearChunkRetry,
+      revokeCurrentChunkUrl,
+      sharedChunkBaseUrl,
+      sumKnownChunkDurations,
+      syncTimelineFromAudio,
+    ]
+  );
+
+  const beginStreamingPlayback = useCallback(async () => {
+    if (streamingActiveRef.current) return;
+
+    streamingActiveRef.current = true;
+    streamingShouldPlayRef.current = true;
+    currentChunkIndexRef.current = null;
+    nextChunkIndexRef.current = 0;
+    streamingOffsetRef.current = 0;
+    chunkDurationsRef.current.clear();
+
+    setCanSeek(false);
+    setState('ready');
+    setPlayback('stopped');
+    setDuration(0);
+    setCurrentTime(0);
+    setProgress(0);
+
+    await tryStartChunkPlayback(0, true);
+  }, [tryStartChunkPlayback]);
+
+  const applyStatus = useCallback(
+    async (statusData: TtsStatusPayload, source: StatusSource): Promise<TtsState> => {
+      generatedChunksRef.current = statusData.generated_chunks;
+      totalChunksRef.current = statusData.total_chunks;
+      generationCompleteRef.current = statusData.status === 'ready';
+      setIsGenerationActive(statusData.status === 'generating');
+
+      if (statusData.status === 'ready') {
         stopPolling();
-        await loadReadyAudio();
+
+        if (streamingActiveRef.current) {
+          setState('ready');
+          if (playbackRef.current === 'stopped') {
+            await loadReadyAudio(false);
+          }
+          return 'ready';
+        }
+
+        const shouldAutoplay = source === 'generate' && generationRequestedRef.current;
+        await loadReadyAudio(shouldAutoplay);
         return 'ready';
       }
-      if (data.status === 'not_generated') {
-        if (!generateRequestInFlightRef.current) {
-          setState('not_generated');
+
+      if (statusData.status === 'generating') {
+        if (!streamingActiveRef.current) {
+          setState('generating');
+        } else {
+          setState('ready');
         }
-        return 'not_generated';
+
+        const canStartPlayback =
+          statusData.playable || statusData.generated_chunks >= MIN_PLAYABLE_CHUNKS;
+        if (
+          canStartPlayback &&
+          generationRequestedRef.current &&
+          !streamingActiveRef.current
+        ) {
+          await beginStreamingPlayback();
+        }
+        return 'generating';
       }
-    } catch {
-      // ignore polling errors
-    }
-    return null;
-  }, [slug, type, loadReadyAudio, stopPolling]);
+
+      if (!generateRequestInFlightRef.current && !streamingActiveRef.current) {
+        setState('not_generated');
+      }
+      return 'not_generated';
+    },
+    [beginStreamingPlayback, loadReadyAudio, stopPolling]
+  );
+
+  const checkStatus = useCallback(
+    async (source: StatusSource = 'poll') => {
+      try {
+        const response = await fetch(
+          `/api/tts/status?slug=${encodeURIComponent(slug)}&type=${encodeURIComponent(type)}`,
+          { cache: 'no-store' }
+        );
+        if (!response.ok) return null;
+        const raw = await response.json();
+        const payload = parseStatusPayload(raw);
+        if (!payload) return null;
+        return await applyStatus(payload, source);
+      } catch {
+        return null;
+      }
+    },
+    [applyStatus, slug, type]
+  );
 
   const startPolling = useCallback(() => {
     if (pollingRef.current) return;
     pollingRef.current = setInterval(() => {
-      void checkStatus();
+      void checkStatus('poll');
     }, STATUS_POLL_INTERVAL_MS);
   }, [checkStatus]);
 
   const handleGenerate = useCallback(async () => {
     setState('generating');
+    setIsGenerationActive(true);
+    setCanSeek(false);
     startPolling();
+    generationRequestedRef.current = true;
     generateRequestInFlightRef.current = true;
 
     try {
-      const res = await fetch('/api/tts/generate', {
+      const response = await fetch('/api/tts/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text, slug, type }),
       });
 
-      if (res.status === 409) {
+      let payload: TtsStatusPayload | null = null;
+      try {
+        payload = parseStatusPayload(await response.json());
+      } catch {
+        payload = null;
+      }
+
+      if (payload) {
+        await applyStatus(payload, 'generate');
         return;
       }
 
-      if (!res.ok) {
-        setState('not_generated');
+      if (response.status === 409 || response.ok) {
+        await checkStatus('generate');
         return;
       }
 
-      stopPolling();
-      await loadReadyAudio(true);
+      setState('not_generated');
+      setIsGenerationActive(false);
+      generationRequestedRef.current = false;
     } catch {
       setState('not_generated');
+      setIsGenerationActive(false);
+      generationRequestedRef.current = false;
     } finally {
       generateRequestInFlightRef.current = false;
     }
-  }, [text, slug, type, loadReadyAudio, startPolling, stopPolling]);
+  }, [applyStatus, checkStatus, slug, startPolling, text, type]);
 
   const handlePlay = useCallback(() => {
-    if (audioRef.current) {
-      audioRef.current.play().catch(() => {
-        setPlayback('stopped');
-      });
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    if (streamingActiveRef.current) {
+      streamingShouldPlayRef.current = true;
+      clearChunkRetry();
+
+      if (audio.src && audio.paused) {
+        audio.play().catch(() => {
+          setPlayback('stopped');
+        });
+        return;
+      }
+
+      void tryStartChunkPlayback(nextChunkIndexRef.current, true);
+      return;
     }
-  }, []);
+
+    audio.play().catch(() => {
+      setPlayback('stopped');
+    });
+  }, [clearChunkRetry, tryStartChunkPlayback]);
 
   const handlePause = useCallback(() => {
-    if (audioRef.current) {
-      audioRef.current.pause();
+    if (!audioRef.current) return;
+    if (streamingActiveRef.current) {
+      streamingShouldPlayRef.current = false;
+      clearChunkRetry();
     }
-  }, []);
+    audioRef.current.pause();
+  }, [clearChunkRetry]);
 
   const handleStop = useCallback(() => {
-    if (audioRef.current) {
-      audioRef.current.pause();
-      audioRef.current.currentTime = 0;
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    if (streamingActiveRef.current) {
+      streamingShouldPlayRef.current = false;
+      clearChunkRetry();
+      audio.pause();
+      audio.currentTime = 0;
+      currentChunkIndexRef.current = null;
+      nextChunkIndexRef.current = 0;
+      streamingOffsetRef.current = 0;
       setPlayback('stopped');
       setCurrentTime(0);
       setProgress(0);
+      if (generationCompleteRef.current) {
+        void loadReadyAudio(false);
+      }
+      return;
     }
-  }, []);
+
+    audio.pause();
+    audio.currentTime = 0;
+    setPlayback('stopped');
+    setCurrentTime(0);
+    setProgress(0);
+  }, [clearChunkRetry, loadReadyAudio]);
 
   useEffect(() => {
     const audio = new Audio();
     audioRef.current = audio;
 
     const handleLoadedMetadata = () => {
+      if (streamingActiveRef.current) {
+        const activeIndex = currentChunkIndexRef.current;
+        if (activeIndex !== null) {
+          const safe = getSafeDuration(audio.duration);
+          if (safe > 0) {
+            chunkDurationsRef.current.set(activeIndex, safe);
+          }
+        }
+      }
       syncTimelineFromAudio();
     };
 
     const handleDurationChange = () => {
+      if (streamingActiveRef.current) {
+        const activeIndex = currentChunkIndexRef.current;
+        if (activeIndex !== null) {
+          const safe = getSafeDuration(audio.duration);
+          if (safe > 0) {
+            chunkDurationsRef.current.set(activeIndex, safe);
+          }
+        }
+      }
       syncTimelineFromAudio();
     };
 
@@ -412,17 +738,48 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
       syncTimelineFromAudio();
     };
 
-    const handlePlaying = () => {
+    const handlePlayingEvent = () => {
       setPlayback('playing');
       syncTimelineFromAudio();
     };
 
-    const handlePause = () => {
+    const handlePauseEvent = () => {
       setPlayback(audio.currentTime > 0 ? 'paused' : 'stopped');
       syncTimelineFromAudio();
     };
 
     const handleEnded = () => {
+      if (streamingActiveRef.current) {
+        const nextIndex =
+          currentChunkIndexRef.current === null
+            ? nextChunkIndexRef.current
+            : currentChunkIndexRef.current + 1;
+
+        nextChunkIndexRef.current = nextIndex;
+
+        if (!streamingShouldPlayRef.current) {
+          setPlayback('paused');
+          return;
+        }
+
+        if (
+          generationCompleteRef.current &&
+          totalChunksRef.current > 0 &&
+          nextIndex >= totalChunksRef.current
+        ) {
+          streamingActiveRef.current = false;
+          streamingShouldPlayRef.current = false;
+          setPlayback('stopped');
+          setCurrentTime(0);
+          setProgress(0);
+          void loadReadyAudio(false);
+          return;
+        }
+
+        void tryStartChunkPlayback(nextIndex, true);
+        return;
+      }
+
       setPlayback('stopped');
       setCurrentTime(0);
       setProgress(0);
@@ -431,29 +788,38 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
     audio.addEventListener('loadedmetadata', handleLoadedMetadata);
     audio.addEventListener('durationchange', handleDurationChange);
     audio.addEventListener('timeupdate', handleTimeUpdate);
-    audio.addEventListener('playing', handlePlaying);
-    audio.addEventListener('pause', handlePause);
+    audio.addEventListener('playing', handlePlayingEvent);
+    audio.addEventListener('pause', handlePauseEvent);
     audio.addEventListener('ended', handleEnded);
 
     return () => {
       audio.removeEventListener('loadedmetadata', handleLoadedMetadata);
       audio.removeEventListener('durationchange', handleDurationChange);
       audio.removeEventListener('timeupdate', handleTimeUpdate);
-      audio.removeEventListener('playing', handlePlaying);
-      audio.removeEventListener('pause', handlePause);
+      audio.removeEventListener('playing', handlePlayingEvent);
+      audio.removeEventListener('pause', handlePauseEvent);
       audio.removeEventListener('ended', handleEnded);
       audio.pause();
       audio.src = '';
       stopPolling();
+      clearChunkRetry();
+      revokeCurrentChunkUrl();
     };
-  }, [stopPolling, syncTimelineFromAudio]);
+  }, [
+    clearChunkRetry,
+    loadReadyAudio,
+    revokeCurrentChunkUrl,
+    stopPolling,
+    syncTimelineFromAudio,
+    tryStartChunkPlayback,
+  ]);
 
   useEffect(() => {
     let isActive = true;
 
     const syncInitialStatus = async () => {
-      const status = await checkStatus();
-      if (!isActive || status === 'ready') return;
+      const currentStatus = await checkStatus('init');
+      if (!isActive || currentStatus === 'ready') return;
       startPolling();
     };
 
@@ -471,6 +837,7 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
   );
 
   const isVisible = (target: TtsState) => state === target;
+  const showGeneratingBadge = state === 'ready' && isGenerationActive;
   const transitionSx = {
     transition: 'opacity 0.35s ease, transform 0.35s ease',
   };
@@ -484,9 +851,13 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
           '0%': { transform: 'translateX(-100%)' },
           '100%': { transform: 'translateX(400%)' },
         },
+        '@keyframes tts-dot-pulse': {
+          '0%': { transform: 'scale(0.85)', opacity: 0.55 },
+          '50%': { transform: 'scale(1)', opacity: 1 },
+          '100%': { transform: 'scale(0.85)', opacity: 0.55 },
+        },
       }}
     >
-      {/* Not generated: full-width Listen button */}
       <Box
         onClick={handleGenerate}
         role="button"
@@ -506,7 +877,7 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
           pointerEvents: isVisible('not_generated') ? 'auto' : 'none',
           position: isVisible('not_generated') ? 'relative' : 'absolute',
           width: '100%',
-          height: 36,
+          height: 44,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -533,7 +904,6 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
         </Typography>
       </Box>
 
-      {/* Generating: traveling pulse bar */}
       <Box
         sx={{
           ...transitionSx,
@@ -542,7 +912,7 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
           pointerEvents: isVisible('generating') ? 'auto' : 'none',
           position: isVisible('generating') ? 'relative' : 'absolute',
           width: '100%',
-          height: 36,
+          height: 44,
           borderRadius: 0,
           bgcolor: 'rgba(255,255,255,0.08)',
           overflow: 'hidden',
@@ -578,11 +948,10 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
             zIndex: 1,
           }}
         >
-          Generating audio...
+          Preparing audio...
         </Typography>
       </Box>
 
-      {/* Ready: full-width playback controls */}
       <Stack
         direction="row"
         spacing={0}
@@ -595,7 +964,7 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
           pointerEvents: isVisible('ready') ? 'auto' : 'none',
           position: isVisible('ready') ? 'relative' : 'absolute',
           width: '100%',
-          height: 36,
+          height: 44,
           borderRadius: 0,
           border: '1px solid',
           borderColor: `${colors.primary}40`,
@@ -612,9 +981,9 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
               aria-label="Pause"
               sx={{
                 borderRadius: 0,
-                width: 36,
-                height: 36,
-                minHeight: 36,
+                width: 44,
+                height: 44,
+                minHeight: 44,
                 color: colors.primary,
                 '&:hover': { bgcolor: `${colors.primary}18` },
                 '&:focus-visible': {
@@ -623,7 +992,7 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
                 },
               }}
             >
-              <Pause size={15} />
+              <Pause size={16} />
             </IconButton>
           ) : (
             <IconButton
@@ -633,9 +1002,9 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
               aria-label="Play"
               sx={{
                 borderRadius: 0,
-                width: 36,
-                height: 36,
-                minHeight: 36,
+                width: 44,
+                height: 44,
+                minHeight: 44,
                 color: colors.primary,
                 '&:hover': { bgcolor: `${colors.primary}18` },
                 '&:focus-visible': {
@@ -644,7 +1013,7 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
                 },
               }}
             >
-              <Play size={15} />
+              <Play size={16} />
             </IconButton>
           )}
           <IconButton
@@ -654,9 +1023,9 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
             aria-label="Stop"
             sx={{
               borderRadius: 0,
-              width: 36,
-              height: 36,
-              minHeight: 36,
+              width: 44,
+              height: 44,
+              minHeight: 44,
               color: colors.primary,
               '&:hover': { bgcolor: `${colors.primary}18` },
               '&:focus-visible': {
@@ -665,7 +1034,7 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
               },
             }}
           >
-            <Square size={12} />
+            <Square size={13} />
           </IconButton>
         </Stack>
 
@@ -675,10 +1044,10 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
             height: '100%',
             position: 'relative',
             bgcolor: 'rgba(255,255,255,0.06)',
-            cursor: 'pointer',
+            cursor: canSeek ? 'pointer' : 'default',
           }}
           onClick={(e) => {
-            if (!audioRef.current || !audioRef.current.duration) return;
+            if (!canSeek || !audioRef.current || !audioRef.current.duration) return;
             const rect = e.currentTarget.getBoundingClientRect();
             const ratio = (e.clientX - rect.left) / rect.width;
             audioRef.current.currentTime = ratio * audioRef.current.duration;
@@ -714,21 +1083,60 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
           />
         </Box>
 
-        <Typography
-          level="body-xs"
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
           sx={{
-            px: 1.25,
-            color: 'text.secondary',
-            fontSize: '0.7rem',
-            fontFamily: 'monospace',
-            whiteSpace: 'nowrap',
+            pl: 1,
+            pr: 1.25,
             flexShrink: 0,
-            minWidth: 80,
-            textAlign: 'right',
           }}
         >
-          {formatTime(currentTime)} / {formatTime(duration)}
-        </Typography>
+          {showGeneratingBadge && (
+            <Stack
+              direction="row"
+              spacing={0.5}
+              alignItems="center"
+              aria-label="Audio generation in progress"
+            >
+              <Box
+                sx={{
+                  width: 6,
+                  height: 6,
+                  borderRadius: '50%',
+                  bgcolor: colors.primary,
+                  animation: 'tts-dot-pulse 1.1s ease-in-out infinite',
+                }}
+              />
+              <Typography
+                level="body-xs"
+                sx={{
+                  color: 'text.secondary',
+                  fontSize: '0.68rem',
+                  letterSpacing: '0.02em',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                Generating...
+              </Typography>
+            </Stack>
+          )}
+
+          <Typography
+            level="body-xs"
+            sx={{
+              color: 'text.secondary',
+              fontSize: '0.7rem',
+              fontFamily: 'monospace',
+              whiteSpace: 'nowrap',
+              minWidth: 80,
+              textAlign: 'right',
+            }}
+          >
+            {formatTime(currentTime)} / {formatTime(duration)}
+          </Typography>
+        </Stack>
       </Stack>
     </Box>
   );

--- a/tts/server.py
+++ b/tts/server.py
@@ -1,15 +1,17 @@
-import asyncio
+import json
 import re
-import struct
+import shutil
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import soundfile as sf
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse
 from kokoro import KModel, KPipeline
 from pydantic import BaseModel
 
@@ -17,8 +19,14 @@ VOICE = "af_heart"
 SAMPLE_RATE = 24000
 TTS_DIR = Path("/tmp/tts")
 LOCK_TIMEOUT = 300
+MIN_PLAYABLE_CHUNKS = 3
+TARGET_CHUNK_CHARS = 480
+MAX_CHUNK_CHARS = 760
+VALID_TYPES = {"blog", "lore"}
 
 active_locks: dict[str, float] = {}
+generation_status: dict[str, dict[str, Any]] = {}
+state_lock = threading.Lock()
 model: KModel | None = None
 pipeline: KPipeline | None = None
 voice_pack = None
@@ -33,29 +41,49 @@ def _cache_path(type_: str, slug: str) -> Path:
     return TTS_DIR / _safe_segment(type_) / f"{_safe_segment(slug)}.wav"
 
 
+def _chunks_dir(type_: str, slug: str) -> Path:
+    return TTS_DIR / _safe_segment(type_) / "_chunks" / _safe_segment(slug)
+
+
+def _chunk_path(type_: str, slug: str, index: int) -> Path:
+    return _chunks_dir(type_, slug) / f"{index:04d}.wav"
+
+
+def _status_path(type_: str, slug: str) -> Path:
+    return _chunks_dir(type_, slug) / "status.json"
+
+
 def _lock_key(type_: str, slug: str) -> str:
     return f"{type_}:{slug}"
 
 
 def _is_locked(type_: str, slug: str) -> bool:
     key = _lock_key(type_, slug)
-    if key not in active_locks:
-        return False
-    if time.time() - active_locks[key] > LOCK_TIMEOUT:
-        del active_locks[key]
-        return False
-    return True
+    now = time.time()
+    with state_lock:
+        locked_at = active_locks.get(key)
+        if locked_at is None:
+            return False
+        if now - locked_at > LOCK_TIMEOUT:
+            active_locks.pop(key, None)
+            return False
+        return True
 
 
 def _acquire_lock(type_: str, slug: str) -> bool:
-    if _is_locked(type_, slug):
-        return False
-    active_locks[_lock_key(type_, slug)] = time.time()
-    return True
+    key = _lock_key(type_, slug)
+    now = time.time()
+    with state_lock:
+        locked_at = active_locks.get(key)
+        if locked_at is not None and now - locked_at <= LOCK_TIMEOUT:
+            return False
+        active_locks[key] = now
+        return True
 
 
 def _release_lock(type_: str, slug: str):
-    active_locks.pop(_lock_key(type_, slug), None)
+    with state_lock:
+        active_locks.pop(_lock_key(type_, slug), None)
 
 
 def _clean_text(text: str) -> str:
@@ -76,29 +104,342 @@ def _clean_text(text: str) -> str:
     return text.strip()
 
 
-STREAMING_DATA_SIZE = 0xFFFFFFFF
+def _split_long_sentence(sentence: str, limit: int) -> list[str]:
+    words = sentence.split()
+    if not words:
+        return []
+
+    parts: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    for word in words:
+        word_len = len(word)
+        if not current:
+            if word_len <= limit:
+                current = [word]
+                current_len = word_len
+            else:
+                for i in range(0, word_len, limit):
+                    parts.append(word[i : i + limit])
+            continue
+
+        projected_len = current_len + 1 + word_len
+        if projected_len <= limit:
+            current.append(word)
+            current_len = projected_len
+            continue
+
+        parts.append(" ".join(current))
+        if word_len <= limit:
+            current = [word]
+            current_len = word_len
+        else:
+            current = []
+            current_len = 0
+            for i in range(0, word_len, limit):
+                parts.append(word[i : i + limit])
+
+    if current:
+        parts.append(" ".join(current))
+    return parts
 
 
-def _wav_header(sample_rate: int, channels: int, bps: int, data_size: int) -> bytes:
-    byte_rate = sample_rate * channels * bps // 8
-    block_align = channels * bps // 8
-    chunk_size = min(36 + data_size, STREAMING_DATA_SIZE)
-    return struct.pack(
-        "<4sI4s4sIHHIIHH4sI",
-        b"RIFF",
-        chunk_size,
-        b"WAVE",
-        b"fmt ",
-        16,
-        1,
-        channels,
-        sample_rate,
-        byte_rate,
-        block_align,
-        bps,
-        b"data",
-        min(data_size, STREAMING_DATA_SIZE),
-    )
+def _text_chunks(cleaned: str) -> list[str]:
+    paragraphs = [p.strip() for p in re.split(r"\n{2,}", cleaned) if p.strip()]
+    if not paragraphs:
+        return []
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    def flush_current():
+        nonlocal current_len
+        if current:
+            chunks.append(" ".join(current).strip())
+            current.clear()
+            current_len = 0
+
+    for paragraph in paragraphs:
+        sentence_candidates = [
+            s.strip() for s in re.split(r"(?<=[.!?])\s+", paragraph) if s.strip()
+        ]
+        if not sentence_candidates:
+            sentence_candidates = [paragraph]
+
+        normalized_sentences: list[str] = []
+        for sentence in sentence_candidates:
+            if len(sentence) > MAX_CHUNK_CHARS:
+                normalized_sentences.extend(
+                    _split_long_sentence(sentence, MAX_CHUNK_CHARS)
+                )
+            else:
+                normalized_sentences.append(sentence)
+
+        for sentence in normalized_sentences:
+            sentence_len = len(sentence)
+            if not current:
+                current = [sentence]
+                current_len = sentence_len
+                continue
+
+            projected_len = current_len + 1 + sentence_len
+            if projected_len > MAX_CHUNK_CHARS:
+                flush_current()
+                current = [sentence]
+                current_len = sentence_len
+                continue
+
+            if current_len >= TARGET_CHUNK_CHARS:
+                flush_current()
+                current = [sentence]
+                current_len = sentence_len
+                continue
+
+            current.append(sentence)
+            current_len = projected_len
+
+    flush_current()
+    return [chunk for chunk in chunks if chunk]
+
+
+def _default_status() -> dict[str, Any]:
+    return {
+        "status": "not_generated",
+        "generated_chunks": 0,
+        "total_chunks": 0,
+        "playable": False,
+    }
+
+
+def _normalize_status(payload: dict[str, Any]) -> dict[str, Any]:
+    status = payload.get("status", "not_generated")
+    if status not in {"not_generated", "generating", "ready"}:
+        status = "not_generated"
+
+    total_chunks = max(0, int(payload.get("total_chunks", 0) or 0))
+    generated_chunks = max(0, int(payload.get("generated_chunks", 0) or 0))
+    if total_chunks > 0:
+        generated_chunks = min(generated_chunks, total_chunks)
+    else:
+        generated_chunks = 0
+
+    playable = bool(payload.get("playable", False))
+    if status == "ready":
+        playable = True
+        if total_chunks > 0:
+            generated_chunks = total_chunks
+
+    normalized: dict[str, Any] = {
+        "status": status,
+        "generated_chunks": generated_chunks,
+        "total_chunks": total_chunks,
+        "playable": playable,
+    }
+
+    error = payload.get("error")
+    if isinstance(error, str) and error:
+        normalized["error"] = error
+
+    return normalized
+
+
+def _write_status(type_: str, slug: str, payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = _normalize_status(payload)
+    key = _lock_key(type_, slug)
+    path = _status_path(type_, slug)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(normalized), encoding="utf-8")
+    tmp_path.replace(path)
+    with state_lock:
+        generation_status[key] = normalized
+    return normalized
+
+
+def _read_status(type_: str, slug: str) -> dict[str, Any] | None:
+    key = _lock_key(type_, slug)
+    with state_lock:
+        cached = generation_status.get(key)
+    if cached is not None:
+        return dict(cached)
+
+    path = _status_path(type_, slug)
+    if not path.exists():
+        return None
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    normalized = _normalize_status(payload)
+    with state_lock:
+        generation_status[key] = normalized
+    return dict(normalized)
+
+
+def _chunk_file_count(type_: str, slug: str) -> int:
+    chunk_dir = _chunks_dir(type_, slug)
+    if not chunk_dir.exists():
+        return 0
+    return sum(1 for _ in chunk_dir.glob("*.wav"))
+
+
+def _current_status(type_: str, slug: str) -> dict[str, Any]:
+    status = _read_status(type_, slug)
+    cache_exists = _cache_path(type_, slug).exists()
+    locked = _is_locked(type_, slug)
+
+    if status is None:
+        if cache_exists:
+            total = _chunk_file_count(type_, slug)
+            return _write_status(
+                type_,
+                slug,
+                {
+                    "status": "ready",
+                    "generated_chunks": total,
+                    "total_chunks": total,
+                    "playable": True,
+                },
+            )
+        if locked:
+            return {
+                "status": "generating",
+                "generated_chunks": 0,
+                "total_chunks": 0,
+                "playable": False,
+            }
+        return _default_status()
+
+    if cache_exists:
+        total = status.get("total_chunks", 0) or _chunk_file_count(type_, slug)
+        return _write_status(
+            type_,
+            slug,
+            {
+                **status,
+                "status": "ready",
+                "generated_chunks": total,
+                "total_chunks": total,
+                "playable": True,
+            },
+        )
+
+    if locked:
+        generated = int(status.get("generated_chunks", 0) or 0)
+        return _normalize_status(
+            {
+                **status,
+                "status": "generating",
+                "playable": generated >= MIN_PLAYABLE_CHUNKS,
+            }
+        )
+
+    if status.get("status") == "ready" and not cache_exists:
+        return _default_status()
+
+    return status
+
+
+def _reset_outputs(type_: str, slug: str):
+    cache = _cache_path(type_, slug)
+    chunks = _chunks_dir(type_, slug)
+    if chunks.exists():
+        shutil.rmtree(chunks, ignore_errors=True)
+    cache.unlink(missing_ok=True)
+
+
+def _synthesize_chunk(text: str) -> np.ndarray:
+    if model is None or pipeline is None or voice_pack is None:
+        raise RuntimeError("TTS model is not initialized")
+
+    parts: list[np.ndarray] = []
+    for _, ps, _ in pipeline(text, voice=VOICE, speed=0.95, split_pattern=r"\n+"):
+        ref_s = voice_pack[len(ps) - 1]
+        audio = model(ps, ref_s, 1)
+        parts.append(audio.numpy())
+
+    if not parts:
+        return np.zeros(int(SAMPLE_RATE * 0.08), dtype=np.float32)
+    return np.concatenate(parts)
+
+
+def _generate_chunks_worker(type_: str, slug: str, chunks: list[str]):
+    key = _lock_key(type_, slug)
+    try:
+        collected: list[np.ndarray] = []
+        total = len(chunks)
+        _write_status(
+            type_,
+            slug,
+            {
+                "status": "generating",
+                "generated_chunks": 0,
+                "total_chunks": total,
+                "playable": False,
+            },
+        )
+
+        for index, chunk_text in enumerate(chunks):
+            audio_chunk = _synthesize_chunk(chunk_text)
+            chunk_path = _chunk_path(type_, slug, index)
+            chunk_path.parent.mkdir(parents=True, exist_ok=True)
+            sf.write(str(chunk_path), audio_chunk, SAMPLE_RATE)
+            collected.append(audio_chunk)
+
+            generated = index + 1
+            _write_status(
+                type_,
+                slug,
+                {
+                    "status": "generating",
+                    "generated_chunks": generated,
+                    "total_chunks": total,
+                    "playable": generated >= MIN_PLAYABLE_CHUNKS,
+                },
+            )
+
+        full_audio = (
+            np.concatenate(collected)
+            if collected
+            else np.zeros(int(SAMPLE_RATE * 0.08), dtype=np.float32)
+        )
+        cache = _cache_path(type_, slug)
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(str(cache), full_audio, SAMPLE_RATE)
+
+        _write_status(
+            type_,
+            slug,
+            {
+                "status": "ready",
+                "generated_chunks": total,
+                "total_chunks": total,
+                "playable": True,
+            },
+        )
+    except Exception as error:
+        _reset_outputs(type_, slug)
+        _write_status(
+            type_,
+            slug,
+            {
+                "status": "not_generated",
+                "generated_chunks": 0,
+                "total_chunks": 0,
+                "playable": False,
+                "error": str(error),
+            },
+        )
+    finally:
+        _release_lock(type_, slug)
+        with state_lock:
+            generation_status.pop(key, None)
 
 
 @asynccontextmanager
@@ -115,6 +456,8 @@ async def lifespan(app: FastAPI):
     TTS_DIR.mkdir(parents=True, exist_ok=True)
     (TTS_DIR / "blog").mkdir(parents=True, exist_ok=True)
     (TTS_DIR / "lore").mkdir(parents=True, exist_ok=True)
+    (TTS_DIR / "blog" / "_chunks").mkdir(parents=True, exist_ok=True)
+    (TTS_DIR / "lore" / "_chunks").mkdir(parents=True, exist_ok=True)
 
     yield
     executor.shutdown(wait=False)
@@ -131,72 +474,74 @@ class GenerateRequest(BaseModel):
 
 @app.post("/generate")
 async def generate(req: GenerateRequest):
-    cache = _cache_path(req.type, req.slug)
+    if req.type not in VALID_TYPES:
+        raise HTTPException(status_code=400, detail='Invalid type, expected "blog" or "lore"')
 
+    cleaned = _clean_text(req.text)
+    if not cleaned:
+        raise HTTPException(status_code=400, detail="No readable text to synthesize")
+
+    cache = _cache_path(req.type, req.slug)
     if cache.exists():
-        return FileResponse(
-            cache,
-            media_type="audio/wav",
-            filename=f"{req.slug}.wav",
-        )
+        return JSONResponse(content=_current_status(req.type, req.slug), status_code=200)
 
     if not _acquire_lock(req.type, req.slug):
-        raise HTTPException(
-            status_code=409,
-            detail="Audio is already being generated for this post",
-        )
+        return JSONResponse(content=_current_status(req.type, req.slug), status_code=409)
 
-    async def _stream():
-        queue: asyncio.Queue = asyncio.Queue()
-        cleaned = _clean_text(req.text)
+    chunks = _text_chunks(cleaned)
+    if not chunks:
+        _release_lock(req.type, req.slug)
+        raise HTTPException(status_code=400, detail="No valid text chunks to synthesize")
 
-        def _worker():
-            chunks = []
-            try:
-                queue.put_nowait(_wav_header(SAMPLE_RATE, 1, 16, STREAMING_DATA_SIZE))
-                for _, ps, _ in pipeline(
-                    cleaned, voice=VOICE, speed=0.95, split_pattern=r"\n+"
-                ):
-                    ref_s = voice_pack[len(ps) - 1]
-                    audio = model(ps, ref_s, 1)
-                    np_audio = audio.numpy()
-                    chunks.append(np_audio)
-                    pcm = (np_audio * 32767).astype(np.int16).tobytes()
-                    queue.put_nowait(pcm)
-                if chunks:
-                    full = np.concatenate(chunks)
-                    cache.parent.mkdir(parents=True, exist_ok=True)
-                    sf.write(str(cache), full, SAMPLE_RATE)
-            except Exception as e:
-                queue.put_nowait(e)
-            finally:
-                _release_lock(req.type, req.slug)
-                queue.put_nowait(None)
+    _reset_outputs(req.type, req.slug)
+    _write_status(
+        req.type,
+        req.slug,
+        {
+            "status": "generating",
+            "generated_chunks": 0,
+            "total_chunks": len(chunks),
+            "playable": False,
+        },
+    )
+    executor.submit(_generate_chunks_worker, req.type, req.slug, chunks)
 
-        asyncio.get_running_loop().run_in_executor(executor, _worker)
-
-        while True:
-            item = await queue.get()
-            if item is None:
-                break
-            if isinstance(item, Exception):
-                raise HTTPException(status_code=500, detail=str(item))
-            yield item
-
-    return StreamingResponse(_stream(), media_type="audio/wav")
+    return JSONResponse(content=_current_status(req.type, req.slug), status_code=202)
 
 
 @app.get("/status")
 async def status(slug: str, type: str):
-    if _is_locked(type, slug):
-        return {"status": "generating"}
-    if _cache_path(type, slug).exists():
-        return {"status": "ready"}
-    return {"status": "not_generated"}
+    if type not in VALID_TYPES:
+        raise HTTPException(status_code=400, detail='Invalid type, expected "blog" or "lore"')
+    return _current_status(type, slug)
+
+
+@app.get("/chunk/{type_}/{slug}/{index}")
+async def chunk(type_: str, slug: str, index: int):
+    if type_ not in VALID_TYPES:
+        raise HTTPException(status_code=400, detail='Invalid type, expected "blog" or "lore"')
+    if index < 0:
+        raise HTTPException(status_code=400, detail="Chunk index must be >= 0")
+
+    chunk_file = _chunk_path(type_, slug, index)
+    if chunk_file.exists():
+        return FileResponse(
+            chunk_file,
+            media_type="audio/wav",
+            filename=f"{slug}-{index:04d}.wav",
+        )
+
+    current = _current_status(type_, slug)
+    if current["status"] == "generating":
+        raise HTTPException(status_code=425, detail="Chunk not ready yet")
+
+    raise HTTPException(status_code=404, detail="Chunk not found")
 
 
 @app.get("/audio/{type_}/{slug}")
 async def audio(type_: str, slug: str):
+    if type_ not in VALID_TYPES:
+        raise HTTPException(status_code=400, detail='Invalid type, expected "blog" or "lore"')
     cache = _cache_path(type_, slug)
     if not cache.exists():
         raise HTTPException(status_code=404, detail="Audio not found")


### PR DESCRIPTION
## Summary
- switch TTS generation from full-response WAV delivery to chunk-aware async generation
- add chunk/status-aware API flow for Next.js (`/api/tts/generate` passthrough JSON, new `/api/tts/chunk/...` proxy)
- add chunk-ready state metadata (`generated_chunks`, `total_chunks`, `playable`) in status responses
- update blog TTS player to begin playback once buffered chunks are available, then continue while generation finishes
- keep normal playback controls visible while showing a subtle `Generating...` indicator during active synthesis

## Backend
- `tts/server.py`
  - add deterministic text chunking and per-chunk WAV persistence
  - add generation status persistence/normalization and lock-safe state handling
  - change `/generate` to async kickoff + JSON status responses
  - add `/chunk/{type_}/{slug}/{index}` endpoint
  - keep final merged `/audio/{type_}/{slug}` output for completed playback

## Frontend/API
- `app/api/tts/generate/route.ts`: forward upstream JSON/status instead of returning WAV body
- `app/api/tts/status/route.ts`: include chunk fields in fallback error payload
- `app/api/tts/chunk/[type]/[slug]/[index]/route.ts`: new chunk proxy route
- `components/blog/TtsPlayer.tsx`:
  - add streaming chunk queue/retry flow
  - start playback after minimum playable chunk threshold
  - keep seek disabled during streamed chunk phase
  - show `Preparing audio...` pre-play and subtle in-player `Generating...` during active generation

## Tests
- updated `components/blog/TtsPlayer.test.tsx` for:
  - chunk-aware status payloads
  - streaming start when generation is playable
  - in-flight generating behavior while request is unresolved
  - non-initiator no-autoplay behavior
  - safe timeline fallback behavior

## Validation
- `bun test components/blog/TtsPlayer.test.tsx` (pass)
- `bun run build` (pass)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
