### PR TITLE
Improve TTS narration flow and voice pacing

### DIFF
--- a/components/blog/TtsPlayer.test.tsx
+++ b/components/blog/TtsPlayer.test.tsx
@@ -408,6 +408,47 @@ describe('TtsPlayer', () => {
     expect(container.textContent ?? '').toContain('Generating...');
   });
 
+  test('shows ready controls and streams when another viewer opens a playable in-progress generation', async () => {
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) {
+        return jsonResponse(
+          payload('generating', {
+            generated_chunks: 12,
+            total_chunks: 420,
+            playable: true,
+          })
+        );
+      }
+
+      if (url.includes('/api/tts/chunk/blog/shared-post/0')) {
+        return wavResponse();
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer();
+
+    expect(await waitForElement(() => getVisibleReadyButton('Play'), 'Expected Play button')).not
+      .toBeNull();
+    expect(getVisibleGeneratingBar()).toBeNull();
+
+    const playButton = getVisibleReadyButton('Play');
+    if (!(playButton instanceof testWindow.HTMLElement)) {
+      throw new Error('Expected visible play button');
+    }
+
+    await act(async () => {
+      playButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(await waitForElement(() => getVisibleReadyButton('Pause'), 'Expected Pause button')).not
+      .toBeNull();
+    expect(lastAudio?.src.startsWith('blob:mock-')).toBe(true);
+    expect(lastAudio?.playCalls).toBeGreaterThan(0);
+  });
+
   test('keeps showing generating bar while local generate request is in flight and not yet playable', async () => {
     const statuses: StatusPayload[] = [payload('not_generated'), payload('not_generated')];
     let resolveGenerate: ((value: Response) => void) | null = null;

--- a/components/blog/TtsPlayer.tsx
+++ b/components/blog/TtsPlayer.tsx
@@ -523,6 +523,25 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
     await tryStartChunkPlayback(0, true);
   }, [tryStartChunkPlayback]);
 
+  const prepareStreamingControls = useCallback(() => {
+    if (streamingActiveRef.current) return;
+
+    clearChunkRetry();
+    revokeCurrentChunkUrl();
+    streamingShouldPlayRef.current = false;
+    currentChunkIndexRef.current = null;
+    nextChunkIndexRef.current = 0;
+    streamingOffsetRef.current = 0;
+    chunkDurationsRef.current.clear();
+
+    setCanSeek(false);
+    setState('ready');
+    setPlayback('stopped');
+    setDuration(0);
+    setCurrentTime(0);
+    setProgress(0);
+  }, [clearChunkRetry, revokeCurrentChunkUrl]);
+
   const applyStatus = useCallback(
     async (statusData: TtsStatusPayload, source: StatusSource): Promise<TtsState> => {
       generatedChunksRef.current = statusData.generated_chunks;
@@ -547,14 +566,17 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
       }
 
       if (statusData.status === 'generating') {
-        if (!streamingActiveRef.current) {
+        const canStartPlayback =
+          statusData.playable || statusData.generated_chunks >= MIN_PLAYABLE_CHUNKS;
+
+        if (!streamingActiveRef.current && canStartPlayback && !generationRequestedRef.current) {
+          prepareStreamingControls();
+        } else if (!streamingActiveRef.current) {
           setState('generating');
         } else {
           setState('ready');
         }
 
-        const canStartPlayback =
-          statusData.playable || statusData.generated_chunks >= MIN_PLAYABLE_CHUNKS;
         if (
           canStartPlayback &&
           generationRequestedRef.current &&
@@ -570,7 +592,7 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
       }
       return 'not_generated';
     },
-    [beginStreamingPlayback, loadReadyAudio, stopPolling]
+    [beginStreamingPlayback, loadReadyAudio, prepareStreamingControls, stopPolling]
   );
 
   const checkStatus = useCallback(
@@ -662,10 +684,15 @@ export function TtsPlayer({ slug, type, text, coverImageUrl }: TtsPlayerProps) {
       return;
     }
 
+    if (!generationCompleteRef.current && generatedChunksRef.current >= MIN_PLAYABLE_CHUNKS) {
+      void beginStreamingPlayback();
+      return;
+    }
+
     audio.play().catch(() => {
       setPlayback('stopped');
     });
-  }, [clearChunkRetry, tryStartChunkPlayback]);
+  }, [beginStreamingPlayback, clearChunkRetry, tryStartChunkPlayback]);
 
   const handlePause = useCallback(() => {
     if (!audioRef.current) return;

--- a/tts/server.py
+++ b/tts/server.py
@@ -172,56 +172,21 @@ def _split_long_sentence(sentence: str, limit: int) -> list[str]:
     return parts
 
 
-def _paragraph_segments(paragraph: str) -> list[str]:
+def _statement_chunks(paragraph: str) -> list[str]:
     sentence_candidates = [
         s.strip() for s in re.split(r"(?<=[.!?])\s+", paragraph) if s.strip()
     ]
     if not sentence_candidates:
         sentence_candidates = [paragraph]
 
-    normalized_sentences: list[str] = []
+    chunks: list[str] = []
     for sentence in sentence_candidates:
         if len(sentence) > MAX_CHUNK_CHARS:
-            normalized_sentences.extend(_split_long_sentence(sentence, MAX_CHUNK_CHARS))
+            chunks.extend(_split_long_sentence(sentence, MAX_CHUNK_CHARS))
         else:
-            normalized_sentences.append(sentence)
+            chunks.append(sentence)
 
-    segments: list[str] = []
-    current: list[str] = []
-    current_len = 0
-
-    def flush_current():
-        nonlocal current_len
-        if current:
-            segments.append(" ".join(current).strip())
-            current.clear()
-            current_len = 0
-
-    for sentence in normalized_sentences:
-        sentence_len = len(sentence)
-        if not current:
-            current = [sentence]
-            current_len = sentence_len
-            continue
-
-        projected_len = current_len + 1 + sentence_len
-        if projected_len > MAX_CHUNK_CHARS:
-            flush_current()
-            current = [sentence]
-            current_len = sentence_len
-            continue
-
-        if current_len >= TARGET_CHUNK_CHARS:
-            flush_current()
-            current = [sentence]
-            current_len = sentence_len
-            continue
-
-        current.append(sentence)
-        current_len = projected_len
-
-    flush_current()
-    return [segment for segment in segments if segment]
+    return [chunk for chunk in chunks if chunk]
 
 
 def _text_chunks(cleaned: str) -> list[str]:
@@ -230,48 +195,10 @@ def _text_chunks(cleaned: str) -> list[str]:
         return []
 
     chunks: list[str] = []
-    current: list[str] = []
-    current_len = 0
-
-    def flush_current():
-        nonlocal current_len
-        if current:
-            chunks.append("\n\n".join(current).strip())
-            current.clear()
-            current_len = 0
 
     for paragraph in paragraphs:
-        paragraph_segments = _paragraph_segments(paragraph)
-        for index, paragraph_segment in enumerate(paragraph_segments):
-            if index > 0:
-                flush_current()
+        chunks.extend(_statement_chunks(paragraph))
 
-            segment_len = len(paragraph_segment)
-            if not current:
-                current = [paragraph_segment]
-                current_len = segment_len
-                continue
-
-            projected_len = current_len + 2 + segment_len
-            if projected_len > MAX_CHUNK_CHARS:
-                flush_current()
-                current = [paragraph_segment]
-                current_len = segment_len
-                continue
-
-            if current_len >= TARGET_CHUNK_CHARS:
-                flush_current()
-                current = [paragraph_segment]
-                current_len = segment_len
-                continue
-
-            current.append(paragraph_segment)
-            current_len = projected_len
-
-        if current_len >= TARGET_CHUNK_CHARS:
-            flush_current()
-
-    flush_current()
     return [chunk for chunk in chunks if chunk]
 
 

--- a/tts/server.py
+++ b/tts/server.py
@@ -15,14 +15,21 @@ from fastapi.responses import FileResponse, JSONResponse
 from kokoro import KModel, KPipeline
 from pydantic import BaseModel
 
-VOICE = "af_heart"
+VOICE = "af_heart,af_bella"
 SAMPLE_RATE = 24000
 TTS_DIR = Path("/tmp/tts")
 LOCK_TIMEOUT = 300
 MIN_PLAYABLE_CHUNKS = 3
-TARGET_CHUNK_CHARS = 480
-MAX_CHUNK_CHARS = 760
+TARGET_CHUNK_CHARS = 640
+MAX_CHUNK_CHARS = 960
 VALID_TYPES = {"blog", "lore"}
+
+STANDARD_DISCLAIMER_RE = re.compile(
+    r"\A\s*(?:>\s*)?(?:\*\*|__)?Disclaimer:(?:\*\*|__)?[^\n]*\n(?:\s*>\s*.*\n?)*\s*",
+    flags=re.IGNORECASE,
+)
+MARKDOWN_HEADING_RE = re.compile(r"^\s*#{1,6}\s+")
+HORIZONTAL_RULE_RE = re.compile(r"^\s*(?:---+|\*\*\*+|___+)\s*$")
 
 active_locks: dict[str, float] = {}
 generation_status: dict[str, dict[str, Any]] = {}
@@ -86,22 +93,42 @@ def _release_lock(type_: str, slug: str):
         active_locks.pop(_lock_key(type_, slug), None)
 
 
+def _strip_standard_disclaimer(text: str) -> str:
+    return STANDARD_DISCLAIMER_RE.sub("", text, count=1)
+
+
 def _clean_text(text: str) -> str:
+    text = text.replace("\r\n", "\n")
+    text = _strip_standard_disclaimer(text)
     text = re.sub(r"\{\{image:[^}]*\}\}", "", text)
     text = re.sub(r"!\[([^\]]*)\]\([^)]*\)", r"\1", text)
     text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
-    text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)
     text = re.sub(r"\*{1,3}([^*]+)\*{1,3}", r"\1", text)
     text = re.sub(r"_{1,3}([^_]+)_{1,3}", r"\1", text)
     text = re.sub(r"```[\s\S]*?```", "", text)
     text = re.sub(r"`([^`]+)`", r"\1", text)
     text = re.sub(r"<[^>]+>", "", text)
-    text = re.sub(r"^---+$", "", text, flags=re.MULTILINE)
-    text = re.sub(r"^>\s+", "", text, flags=re.MULTILINE)
-    text = re.sub(r"^\s*[-*+]\s+", "", text, flags=re.MULTILINE)
-    text = re.sub(r"^\s*\d+\.\s+", "", text, flags=re.MULTILINE)
-    text = re.sub(r"\n{3,}", "\n\n", text)
-    return text.strip()
+
+    cleaned_lines: list[str] = []
+    for raw_line in text.splitlines():
+        if MARKDOWN_HEADING_RE.match(raw_line) or HORIZONTAL_RULE_RE.match(raw_line):
+            continue
+
+        line = re.sub(r"^>\s+", "", raw_line)
+        line = re.sub(r"^\s*[-*+]\s+", "", line)
+        line = re.sub(r"^\s*\d+\.\s+", "", line)
+        line = line.strip()
+
+        if not line:
+            if cleaned_lines and cleaned_lines[-1] != "":
+                cleaned_lines.append("")
+            continue
+
+        cleaned_lines.append(line)
+
+    cleaned = "\n".join(cleaned_lines)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
 
 
 def _split_long_sentence(sentence: str, limit: int) -> list[str]:
@@ -145,6 +172,58 @@ def _split_long_sentence(sentence: str, limit: int) -> list[str]:
     return parts
 
 
+def _paragraph_segments(paragraph: str) -> list[str]:
+    sentence_candidates = [
+        s.strip() for s in re.split(r"(?<=[.!?])\s+", paragraph) if s.strip()
+    ]
+    if not sentence_candidates:
+        sentence_candidates = [paragraph]
+
+    normalized_sentences: list[str] = []
+    for sentence in sentence_candidates:
+        if len(sentence) > MAX_CHUNK_CHARS:
+            normalized_sentences.extend(_split_long_sentence(sentence, MAX_CHUNK_CHARS))
+        else:
+            normalized_sentences.append(sentence)
+
+    segments: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    def flush_current():
+        nonlocal current_len
+        if current:
+            segments.append(" ".join(current).strip())
+            current.clear()
+            current_len = 0
+
+    for sentence in normalized_sentences:
+        sentence_len = len(sentence)
+        if not current:
+            current = [sentence]
+            current_len = sentence_len
+            continue
+
+        projected_len = current_len + 1 + sentence_len
+        if projected_len > MAX_CHUNK_CHARS:
+            flush_current()
+            current = [sentence]
+            current_len = sentence_len
+            continue
+
+        if current_len >= TARGET_CHUNK_CHARS:
+            flush_current()
+            current = [sentence]
+            current_len = sentence_len
+            continue
+
+        current.append(sentence)
+        current_len = projected_len
+
+    flush_current()
+    return [segment for segment in segments if segment]
+
+
 def _text_chunks(cleaned: str) -> list[str]:
     paragraphs = [p.strip() for p in re.split(r"\n{2,}", cleaned) if p.strip()]
     if not paragraphs:
@@ -157,48 +236,40 @@ def _text_chunks(cleaned: str) -> list[str]:
     def flush_current():
         nonlocal current_len
         if current:
-            chunks.append(" ".join(current).strip())
+            chunks.append("\n\n".join(current).strip())
             current.clear()
             current_len = 0
 
     for paragraph in paragraphs:
-        sentence_candidates = [
-            s.strip() for s in re.split(r"(?<=[.!?])\s+", paragraph) if s.strip()
-        ]
-        if not sentence_candidates:
-            sentence_candidates = [paragraph]
+        paragraph_segments = _paragraph_segments(paragraph)
+        for index, paragraph_segment in enumerate(paragraph_segments):
+            if index > 0:
+                flush_current()
 
-        normalized_sentences: list[str] = []
-        for sentence in sentence_candidates:
-            if len(sentence) > MAX_CHUNK_CHARS:
-                normalized_sentences.extend(
-                    _split_long_sentence(sentence, MAX_CHUNK_CHARS)
-                )
-            else:
-                normalized_sentences.append(sentence)
-
-        for sentence in normalized_sentences:
-            sentence_len = len(sentence)
+            segment_len = len(paragraph_segment)
             if not current:
-                current = [sentence]
-                current_len = sentence_len
+                current = [paragraph_segment]
+                current_len = segment_len
                 continue
 
-            projected_len = current_len + 1 + sentence_len
+            projected_len = current_len + 2 + segment_len
             if projected_len > MAX_CHUNK_CHARS:
                 flush_current()
-                current = [sentence]
-                current_len = sentence_len
+                current = [paragraph_segment]
+                current_len = segment_len
                 continue
 
             if current_len >= TARGET_CHUNK_CHARS:
                 flush_current()
-                current = [sentence]
-                current_len = sentence_len
+                current = [paragraph_segment]
+                current_len = segment_len
                 continue
 
-            current.append(sentence)
+            current.append(paragraph_segment)
             current_len = projected_len
+
+        if current_len >= TARGET_CHUNK_CHARS:
+            flush_current()
 
     flush_current()
     return [chunk for chunk in chunks if chunk]

--- a/tts/server.py
+++ b/tts/server.py
@@ -430,7 +430,7 @@ def _synthesize_chunk(text: str) -> np.ndarray:
         raise RuntimeError("TTS model is not initialized")
 
     parts: list[np.ndarray] = []
-    for _, ps, _ in pipeline(text, voice=VOICE, speed=0.95, split_pattern=r"\n+"):
+    for _, ps, _ in pipeline(text, voice=VOICE, speed=0.85, split_pattern=r"\n+"):
         ref_s = voice_pack[len(ps) - 1]
         audio = model(ps, ref_s, 1)
         parts.append(audio.numpy())

--- a/tts/tests/test_server.py
+++ b/tts/tests/test_server.py
@@ -33,7 +33,7 @@ Another line.
 
         self.assertEqual(cleaned, "Paragraph with emphasis and signal.\n\nAnother line.")
 
-    def test_text_chunks_preserve_paragraph_boundaries_without_spoken_headings(self):
+    def test_text_chunks_emit_one_statement_per_chunk_without_spoken_headings(self):
         source = """
 ## Transit
 
@@ -49,16 +49,19 @@ About one hour into the drive, near the 212 intersection, I registered a roadsid
         self.assertEqual(
             chunks,
             [
-                "Her predictive pattern had been reliable before. I took it seriously.\n\nAbout one hour into the drive, near the 212 intersection, I registered a roadside anomaly."
+                "Her predictive pattern had been reliable before.",
+                "I took it seriously.",
+                "About one hour into the drive, near the 212 intersection, I registered a roadside anomaly.",
             ],
         )
 
-    def test_text_chunks_flush_between_large_paragraph_segments(self):
-        paragraph = " ".join(["Sentence." for _ in range(80)])
+    def test_text_chunks_split_long_statements_by_word_boundary(self):
+        paragraph = " ".join(["Sentence" for _ in range(200)]) + "."
 
         chunks = _text_chunks(_clean_text(paragraph))
 
         self.assertGreaterEqual(len(chunks), 2)
+        self.assertTrue(all(len(chunk) <= 960 for chunk in chunks))
         self.assertTrue(all("\n\n" not in chunk for chunk in chunks))
 
 

--- a/tts/tests/test_server.py
+++ b/tts/tests/test_server.py
@@ -1,0 +1,66 @@
+import unittest
+
+from server import _clean_text, _text_chunks
+
+
+class TtsServerTest(unittest.TestCase):
+    def test_clean_text_removes_standard_disclaimer_and_headings(self):
+        source = """
+> **Disclaimer:** This file is fictional roleplay writing created for a
+> tabletop RPG context. It may use real names or familiar details.
+
+## Reduced Visibility
+
+One week after the ER, I was dust.
+""".strip()
+
+        cleaned = _clean_text(source)
+
+        self.assertNotIn("Disclaimer:", cleaned)
+        self.assertNotIn("Reduced Visibility", cleaned)
+        self.assertEqual(cleaned, "One week after the ER, I was dust.")
+
+    def test_clean_text_keeps_inline_emphasis_but_drops_hrules(self):
+        source = """
+Paragraph with **emphasis** and __signal__.
+
+---
+
+Another line.
+""".strip()
+
+        cleaned = _clean_text(source)
+
+        self.assertEqual(cleaned, "Paragraph with emphasis and signal.\n\nAnother line.")
+
+    def test_text_chunks_preserve_paragraph_boundaries_without_spoken_headings(self):
+        source = """
+## Transit
+
+Her predictive pattern had been reliable before. I took it seriously.
+
+## Arrival
+
+About one hour into the drive, near the 212 intersection, I registered a roadside anomaly.
+""".strip()
+
+        chunks = _text_chunks(_clean_text(source))
+
+        self.assertEqual(
+            chunks,
+            [
+                "Her predictive pattern had been reliable before. I took it seriously.\n\nAbout one hour into the drive, near the 212 intersection, I registered a roadside anomaly."
+            ],
+        )
+
+    def test_text_chunks_flush_between_large_paragraph_segments(self):
+        paragraph = " ".join(["Sentence." for _ in range(80)])
+
+        chunks = _text_chunks(_clean_text(paragraph))
+
+        self.assertGreaterEqual(len(chunks), 2)
+        self.assertTrue(all("\n\n" not in chunk for chunk in chunks))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- strip the standard disclaimer and standalone markdown headings from spoken TTS input so lore playback starts on the story instead of page scaffolding
- switch Kokoro to an `af_heart,af_bella` mix, slow playback from `0.95` to `0.85`, and test a statement-per-chunk layout on this branch for TTS vibe checking
- fix `TtsPlayer` so viewers who open an already-playable in-progress generation get the ready controls and can stream chunk playback immediately instead of staying stuck on `Preparing audio...`

## Testing
- `uv run python -m unittest discover -s tests -v`
- `bun test components/blog/TtsPlayer.test.tsx`
- regenerated `lore/w-e-a-v-e-rumbodo` through `http://127.0.0.1:3000/api/tts/generate` after clearing `/tmp/tts`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
