### PR TITLE
Add safe thinking-tag rendering for posts

### DIFF
--- a/blog/posts/2026-04-28.md
+++ b/blog/posts/2026-04-28.md
@@ -12,6 +12,12 @@ This window felt like a reading-first reset for Midori AI.
 The lore page finally reads like a real story space, and the rest of
 the site followed its lead.
 
+<thinking>
+
+This is where the site stops treating lore like loose notes and starts letting it breathe like an actual reading room.
+
+</thinking>
+
 The cover art for this update is a warm cafe scene:
 Riley's blue-faded hair and glasses on the left, Luna's halo
 catching the room glow on the right. It has a coffee-went-cold

--- a/blog/posts/2026-04-28.md
+++ b/blog/posts/2026-04-28.md
@@ -12,12 +12,6 @@ This window felt like a reading-first reset for Midori AI.
 The lore page finally reads like a real story space, and the rest of
 the site followed its lead.
 
-<thinking>
-
-This is where the site stops treating lore like loose notes and starts letting it breathe like an actual reading room.
-
-</thinking>
-
 The cover art for this update is a warm cafe scene:
 Riley's blue-faded hair and glasses on the left, Luna's halo
 catching the room glow on the right. It has a coffee-went-cold

--- a/components/blog/PostView.test.tsx
+++ b/components/blog/PostView.test.tsx
@@ -139,6 +139,14 @@ describe('PostView', () => {
     expect(html).not.toContain('&lt;/thinking&gt;');
   });
 
+  test('renders thinking without the old trailing dot effect', () => {
+    const html = renderPostContent('<thinking>No dot please.</thinking>');
+
+    expect(countThinkingNodes(html)).toBe(1);
+    expect(html).not.toContain('thinking-dot-pulse');
+    expect(html).not.toContain('[data-thinking]::after');
+  });
+
   test('keeps markdown formatting inside thinking tags', () => {
     const html = renderPostContent('<thinking>**bold** [link](https://example.com)</thinking>');
 

--- a/components/blog/PostView.test.tsx
+++ b/components/blog/PostView.test.tsx
@@ -34,6 +34,10 @@ function countDialogueSpans(html: string): number {
   return (html.match(/<span data-dialogue="true"/g) ?? []).length;
 }
 
+function countThinkingNodes(html: string): number {
+  return (html.match(/<(?:span|div) data-thinking=/g) ?? []).length;
+}
+
 describe('PostView', () => {
   test('scheduled preview hides markdown content and shows teaser copy', () => {
     const html = renderToStaticMarkup(
@@ -123,5 +127,40 @@ describe('PostView', () => {
     const html = renderPostContent('Use `a—b` as the token.');
 
     expect(html).toContain('<code>a—b</code>');
+  });
+
+  test('renders inline thinking tags as styled content without showing tags', () => {
+    const html = renderPostContent('Before <thinking>fuck</thinking> after.');
+
+    expect(countThinkingNodes(html)).toBe(1);
+    expect(html).toContain('data-thinking="inline"');
+    expect(html).toContain('fuck');
+    expect(html).not.toContain('&lt;thinking&gt;');
+    expect(html).not.toContain('&lt;/thinking&gt;');
+  });
+
+  test('keeps markdown formatting inside thinking tags', () => {
+    const html = renderPostContent('<thinking>**bold** [link](https://example.com)</thinking>');
+
+    expect(countThinkingNodes(html)).toBe(1);
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<a href="https://example.com">link</a>');
+  });
+
+  test('renders multi-paragraph thinking tags as a block', () => {
+    const html = renderPostContent('<thinking>\n\nFirst thought.\n\nSecond thought.\n\n</thinking>');
+
+    expect(countThinkingNodes(html)).toBe(1);
+    expect(html).toContain('data-thinking="block"');
+    expect(html).toContain('<p>First thought.</p>');
+    expect(html).toContain('<p>Second thought.</p>');
+  });
+
+  test('drops mismatched thinking tags while keeping readable text', () => {
+    const html = renderPostContent('<thinking>Still readable.');
+
+    expect(countThinkingNodes(html)).toBe(0);
+    expect(html).toContain('Still readable.');
+    expect(html).not.toContain('&lt;thinking&gt;');
   });
 });

--- a/components/blog/PostView.tsx
+++ b/components/blog/PostView.tsx
@@ -29,9 +29,10 @@ import {
 import ReactMarkdown from 'react-markdown';
 import type { Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeDialogueQuotes from '@/lib/markdown/rehypeDialogueQuotes';
+import remarkThinkingTags from '@/lib/markdown/remarkThinkingTags';
 import { ArrowLeft, Calendar, User, Tag, ChevronLeft, ChevronRight } from 'lucide-react';
 import {
   extractIsoDateFromBlogFilename,
@@ -90,6 +91,21 @@ function getPostDateString(post: ParsedPost): string | undefined {
 }
 
 const LORE_IMAGE_TOKEN_TITLE = 'lore-token';
+
+const markdownSanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    span: [
+      ...(defaultSchema.attributes?.span ?? []),
+      ['data-thinking', 'inline', 'block'],
+    ],
+    div: [
+      ...(defaultSchema.attributes?.div ?? []),
+      ['data-thinking', 'inline', 'block'],
+    ],
+  },
+};
 
 function replaceLoreImageTokens(markdown: string): string {
   return markdown.replace(/\{\{\s*image\s*:\s*([^}]+?)\s*\}\}/gi, (fullMatch, tokenValue: string) => {
@@ -314,6 +330,28 @@ export function PostView({
         '@keyframes shimmer': {
           '0%': { backgroundPosition: '-1000px 0' },
           '100%': { backgroundPosition: '1000px 0' }
+        },
+        '@keyframes thinking-pulse': {
+          '0%, 100%': {
+            opacity: 0.76,
+            textShadow: '0 0 0 rgba(125, 211, 252, 0)',
+          },
+          '50%': {
+            opacity: 1,
+            textShadow: '0 0 18px rgba(125, 211, 252, 0.55)',
+          },
+        },
+        '@keyframes thinking-dot-pulse': {
+          '0%, 100%': {
+            transform: 'scale(0.72)',
+            opacity: 0.38,
+            boxShadow: '0 0 0 rgba(125, 211, 252, 0)',
+          },
+          '50%': {
+            transform: 'scale(1)',
+            opacity: 1,
+            boxShadow: '0 0 16px rgba(125, 211, 252, 0.85)',
+          },
         },
         ...AMBIENT_PULSE_KEYFRAMES,
       }}
@@ -717,6 +755,45 @@ export function PostView({
               '& [data-dialogue="true"]': {
                 color: dialogueColor,
               },
+              '& [data-thinking]': {
+                position: 'relative',
+                color: '#bae6fd',
+                fontStyle: 'italic',
+                animation: 'thinking-pulse 2.6s ease-in-out infinite',
+                '&::after': {
+                  content: '""',
+                  display: 'inline-block',
+                  width: '0.42em',
+                  height: '0.42em',
+                  ml: 0.75,
+                  mb: '0.12em',
+                  borderRadius: '999px',
+                  backgroundColor: '#7dd3fc',
+                  verticalAlign: 'middle',
+                  animation: 'thinking-dot-pulse 1.7s ease-in-out infinite',
+                },
+              },
+              '& [data-thinking="inline"]': {
+                textWrap: 'pretty',
+              },
+              '& [data-thinking="block"]': {
+                display: 'block',
+                my: 4,
+                p: { xs: 2, sm: 2.5 },
+                border: '1px solid rgba(125, 211, 252, 0.22)',
+                borderLeft: '4px solid rgba(125, 211, 252, 0.65)',
+                background:
+                  'linear-gradient(135deg, rgba(14, 116, 144, 0.16), rgba(59, 130, 246, 0.08) 45%, rgba(255, 255, 255, 0.035))',
+                boxShadow: 'inset 0 0 28px rgba(125, 211, 252, 0.08)',
+                '& p:last-child': {
+                  mb: 0,
+                },
+              },
+              '@media (prefers-reduced-motion: reduce)': {
+                '& [data-thinking], & [data-thinking]::after': {
+                  animation: 'none',
+                },
+              },
               '& img': {
                 maxWidth: '100%',
                 height: 'auto',
@@ -757,8 +834,8 @@ export function PostView({
             }}
           >
             <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeSanitize, rehypeHighlight, rehypeDialogueQuotes]}
+              remarkPlugins={[remarkGfm, remarkThinkingTags]}
+              rehypePlugins={[[rehypeSanitize, markdownSanitizeSchema], rehypeHighlight, rehypeDialogueQuotes]}
               components={markdownComponents}
             >
               {markdownContent}

--- a/components/blog/PostView.tsx
+++ b/components/blog/PostView.tsx
@@ -309,6 +309,10 @@ export function PostView({
     () => hexToRgba(ttsPrimaryColor, 0.55, 'rgba(125, 211, 252, 0.55)'),
     [ttsPrimaryColor]
   );
+  const thinkingMutedColor = useMemo(
+    () => hexToRgba(ttsPrimaryColor, 0.62, 'rgba(186, 230, 253, 0.62)'),
+    [ttsPrimaryColor]
+  );
   const thinkingBorderColor = useMemo(
     () => hexToRgba(ttsPrimaryColor, 0.68, 'rgba(125, 211, 252, 0.65)'),
     [ttsPrimaryColor]
@@ -372,10 +376,12 @@ export function PostView({
         '@keyframes thinking-pulse': {
           '0%, 100%': {
             opacity: 0.76,
+            backgroundPosition: '160% 50%',
             textShadow: '0 0 0 transparent',
           },
           '50%': {
             opacity: 1,
+            backgroundPosition: '20% 50%',
             textShadow: '0 0 18px var(--PostView-thinking-glow)',
           },
         },
@@ -782,11 +788,22 @@ export function PostView({
                 color: dialogueColor,
               },
               '& [data-thinking]': {
+                '--PostView-thinking-color': thinkingColor,
                 '--PostView-thinking-glow': thinkingGlowColor,
+                '--PostView-thinking-muted': thinkingMutedColor,
                 position: 'relative',
-                color: thinkingColor,
                 fontStyle: 'italic',
-                animation: 'thinking-pulse 2.6s ease-in-out infinite',
+              },
+              '& [data-thinking], & [data-thinking] p, & [data-thinking] li, & [data-thinking] span, & [data-thinking] strong, & [data-thinking] em, & [data-thinking] a': {
+                color: 'var(--PostView-thinking-color)',
+                background:
+                  'linear-gradient(90deg, var(--PostView-thinking-muted) 0%, var(--PostView-thinking-color) 32%, rgba(255,255,255,0.96) 48%, var(--PostView-thinking-color) 64%, var(--PostView-thinking-muted) 100%)',
+                backgroundSize: '260% 100%',
+                backgroundPosition: '160% 50%',
+                WebkitBackgroundClip: 'text',
+                backgroundClip: 'text',
+                WebkitTextFillColor: 'transparent',
+                animation: 'thinking-pulse 9s ease-in-out infinite',
               },
               '& [data-thinking="inline"]': {
                 textWrap: 'pretty',
@@ -808,8 +825,10 @@ export function PostView({
                 },
               },
               '@media (prefers-reduced-motion: reduce)': {
-                '& [data-thinking]': {
+                '& [data-thinking], & [data-thinking] p, & [data-thinking] li, & [data-thinking] span, & [data-thinking] strong, & [data-thinking] em, & [data-thinking] a': {
                   animation: 'none',
+                  background: 'none',
+                  WebkitTextFillColor: 'currentColor',
                 },
               },
               '& img': {

--- a/components/blog/PostView.tsx
+++ b/components/blog/PostView.tsx
@@ -138,6 +138,20 @@ function lightenHexColor(hex: string, ratio: number): string {
   return `rgb(${mix(red)}, ${mix(green)}, ${mix(blue)})`;
 }
 
+function hexToRgba(hex: string | null, alpha: number, fallback: string): string {
+  const normalized = hex?.trim().replace(/^#/, '') ?? '';
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    return fallback;
+  }
+
+  const clampAlpha = Math.max(0, Math.min(1, alpha));
+  const red = Number.parseInt(normalized.slice(0, 2), 16);
+  const green = Number.parseInt(normalized.slice(2, 4), 16);
+  const blue = Number.parseInt(normalized.slice(4, 6), 16);
+
+  return `rgba(${red}, ${green}, ${blue}, ${clampAlpha})`;
+}
+
 function buildTooltipText(
   prefix: string,
   story: { title: string; summary?: string } | null | undefined
@@ -287,6 +301,30 @@ export function PostView({
     () => (ttsPrimaryColor ? lightenHexColor(ttsPrimaryColor, 0.18) : 'var(--joy-palette-primary-400)'),
     [ttsPrimaryColor]
   );
+  const thinkingColor = useMemo(
+    () => (ttsPrimaryColor ? lightenHexColor(ttsPrimaryColor, 0.2) : '#bae6fd'),
+    [ttsPrimaryColor]
+  );
+  const thinkingGlowColor = useMemo(
+    () => hexToRgba(ttsPrimaryColor, 0.55, 'rgba(125, 211, 252, 0.55)'),
+    [ttsPrimaryColor]
+  );
+  const thinkingBorderColor = useMemo(
+    () => hexToRgba(ttsPrimaryColor, 0.68, 'rgba(125, 211, 252, 0.65)'),
+    [ttsPrimaryColor]
+  );
+  const thinkingSoftBorderColor = useMemo(
+    () => hexToRgba(ttsPrimaryColor, 0.24, 'rgba(125, 211, 252, 0.22)'),
+    [ttsPrimaryColor]
+  );
+  const thinkingStrongBackground = useMemo(
+    () => hexToRgba(ttsPrimaryColor, 0.16, 'rgba(14, 116, 144, 0.16)'),
+    [ttsPrimaryColor]
+  );
+  const thinkingSoftBackground = useMemo(
+    () => hexToRgba(ttsPrimaryColor, 0.07, 'rgba(59, 130, 246, 0.08)'),
+    [ttsPrimaryColor]
+  );
   const hasLoreStoryNavigation = postType === 'lore' && (previousStory || nextStory);
 
   useEffect(() => {
@@ -334,23 +372,11 @@ export function PostView({
         '@keyframes thinking-pulse': {
           '0%, 100%': {
             opacity: 0.76,
-            textShadow: '0 0 0 rgba(125, 211, 252, 0)',
+            textShadow: '0 0 0 transparent',
           },
           '50%': {
             opacity: 1,
-            textShadow: '0 0 18px rgba(125, 211, 252, 0.55)',
-          },
-        },
-        '@keyframes thinking-dot-pulse': {
-          '0%, 100%': {
-            transform: 'scale(0.72)',
-            opacity: 0.38,
-            boxShadow: '0 0 0 rgba(125, 211, 252, 0)',
-          },
-          '50%': {
-            transform: 'scale(1)',
-            opacity: 1,
-            boxShadow: '0 0 16px rgba(125, 211, 252, 0.85)',
+            textShadow: '0 0 18px var(--PostView-thinking-glow)',
           },
         },
         ...AMBIENT_PULSE_KEYFRAMES,
@@ -756,22 +782,11 @@ export function PostView({
                 color: dialogueColor,
               },
               '& [data-thinking]': {
+                '--PostView-thinking-glow': thinkingGlowColor,
                 position: 'relative',
-                color: '#bae6fd',
+                color: thinkingColor,
                 fontStyle: 'italic',
                 animation: 'thinking-pulse 2.6s ease-in-out infinite',
-                '&::after': {
-                  content: '""',
-                  display: 'inline-block',
-                  width: '0.42em',
-                  height: '0.42em',
-                  ml: 0.75,
-                  mb: '0.12em',
-                  borderRadius: '999px',
-                  backgroundColor: '#7dd3fc',
-                  verticalAlign: 'middle',
-                  animation: 'thinking-dot-pulse 1.7s ease-in-out infinite',
-                },
               },
               '& [data-thinking="inline"]': {
                 textWrap: 'pretty',
@@ -780,17 +795,20 @@ export function PostView({
                 display: 'block',
                 my: 4,
                 p: { xs: 2, sm: 2.5 },
-                border: '1px solid rgba(125, 211, 252, 0.22)',
-                borderLeft: '4px solid rgba(125, 211, 252, 0.65)',
+                border: `1px solid ${thinkingSoftBorderColor}`,
+                borderLeft: `4px solid ${thinkingBorderColor}`,
                 background:
-                  'linear-gradient(135deg, rgba(14, 116, 144, 0.16), rgba(59, 130, 246, 0.08) 45%, rgba(255, 255, 255, 0.035))',
-                boxShadow: 'inset 0 0 28px rgba(125, 211, 252, 0.08)',
-                '& p:last-child': {
-                  mb: 0,
+                  `linear-gradient(135deg, ${thinkingStrongBackground}, ${thinkingSoftBackground} 45%, rgba(255, 255, 255, 0.035))`,
+                boxShadow: `inset 0 0 28px ${thinkingSoftBackground}, 0 0 24px ${thinkingSoftBackground}`,
+                '& p': {
+                  my: 0,
+                },
+                '& p + p': {
+                  mt: 2,
                 },
               },
               '@media (prefers-reduced-motion: reduce)': {
-                '& [data-thinking], & [data-thinking]::after': {
+                '& [data-thinking]': {
                   animation: 'none',
                 },
               },

--- a/components/blog/PostView.tsx
+++ b/components/blog/PostView.tsx
@@ -375,7 +375,7 @@ export function PostView({
         },
         '@keyframes thinking-pulse': {
           '0%, 100%': {
-            opacity: 0.76,
+            opacity: 0.92,
             backgroundPosition: '160% 50%',
             textShadow: '0 0 0 transparent',
           },
@@ -803,7 +803,7 @@ export function PostView({
                 WebkitBackgroundClip: 'text',
                 backgroundClip: 'text',
                 WebkitTextFillColor: 'transparent',
-                animation: 'thinking-pulse 9s ease-in-out infinite',
+                animation: 'thinking-pulse 18s ease-in-out infinite',
               },
               '& [data-thinking="inline"]': {
                 textWrap: 'pretty',

--- a/lib/markdown/remarkThinkingTags.ts
+++ b/lib/markdown/remarkThinkingTags.ts
@@ -1,0 +1,104 @@
+import type { Content, Html, Parent, Root } from 'mdast';
+import type { Plugin } from 'unified';
+
+const OPENING_THINKING_TAG = /^<thinking\s*>$/i;
+const CLOSING_THINKING_TAG = /^<\/thinking\s*>$/i;
+
+interface ThinkingNode extends Parent {
+  type: 'thinking';
+  data: {
+    hName: 'span' | 'div';
+    hProperties: {
+      'data-thinking': 'inline' | 'block';
+    };
+  };
+  children: Content[];
+}
+
+function isParentContent(node: Content): node is Content & Parent {
+  return Array.isArray((node as Parent).children);
+}
+
+function isHtml(node: Content): node is Html {
+  return node.type === 'html';
+}
+
+function isOpeningThinkingTag(node: Content): boolean {
+  return isHtml(node) && OPENING_THINKING_TAG.test(node.value.trim());
+}
+
+function isClosingThinkingTag(node: Content): boolean {
+  return isHtml(node) && CLOSING_THINKING_TAG.test(node.value.trim());
+}
+
+function createThinkingNode(variant: 'inline' | 'block', children: Content[]): ThinkingNode {
+  return {
+    type: 'thinking',
+    data: {
+      hName: variant === 'inline' ? 'span' : 'div',
+      hProperties: {
+        'data-thinking': variant,
+      },
+    },
+    children,
+  };
+}
+
+function findClosingTag(children: Content[], startIndex: number): number {
+  for (let index = startIndex + 1; index < children.length; index += 1) {
+    const child = children[index];
+    if (child && isClosingThinkingTag(child)) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function transformParent(parent: Parent | Root): void {
+  const transformedChildren: Array<Content | ThinkingNode> = [];
+  const parentIsParagraph = parent.type === 'paragraph';
+
+  for (const child of parent.children as Content[]) {
+    if (isParentContent(child)) {
+      transformParent(child);
+    }
+  }
+
+  for (let index = 0; index < parent.children.length; index += 1) {
+    const child = parent.children[index] as Content | undefined;
+
+    if (!child) {
+      continue;
+    }
+
+    if (isOpeningThinkingTag(child)) {
+      const closingIndex = findClosingTag(parent.children as Content[], index);
+
+      if (closingIndex === -1) {
+        continue;
+      }
+
+      const innerChildren = (parent.children as Content[]).slice(index + 1, closingIndex);
+      transformedChildren.push(createThinkingNode(parentIsParagraph ? 'inline' : 'block', innerChildren));
+      index = closingIndex;
+      continue;
+    }
+
+    if (isClosingThinkingTag(child)) {
+      continue;
+    }
+
+    transformedChildren.push(child);
+  }
+
+  parent.children = transformedChildren as Parent['children'];
+}
+
+const remarkThinkingTags: Plugin<[], Root> = () => {
+  return (tree) => {
+    transformParent(tree);
+  };
+};
+
+export default remarkThinkingTags;


### PR DESCRIPTION
## Summary

This PR adds author-facing `<thinking>...</thinking>` syntax for blog and lore markdown content. The literal tags are not shown to readers. Instead, matched thinking tags are converted into safe internal `data-thinking` elements and rendered with a subtle cover-colored thought effect in `PostView`.

The feature supports both inline and multi-paragraph usage:

- Inline usage, such as `Before <thinking>quiet thought</thinking> after`, renders as an inline thought span.
- Block usage, such as opening and closing `<thinking>` tags around one or more markdown paragraphs, renders as a thought panel.
- Markdown inside thinking tags continues to render normally, including strong text and links.

## Implementation Details

- Added `lib/markdown/remarkThinkingTags.ts`, a typed remark plugin that scans mdast children for paired `<thinking>` and `</thinking>` HTML nodes before sanitization.
- The plugin converts matched pairs into mdast nodes with `data.hName` and `data.hProperties`, producing either `span data-thinking="inline"` or `div data-thinking="block"` depending on whether the pair appears inside a paragraph or at block level.
- Unmatched or stray thinking tags are removed while preserving readable inner text where possible, so malformed content does not expose raw authoring syntax to readers.
- Updated `components/blog/PostView.tsx` to register the new remark plugin alongside `remark-gfm`.
- Extended the existing `rehype-sanitize` schema narrowly so only `data-thinking="inline"` and `data-thinking="block"` are allowed on `span` and `div`; this avoids broad raw-HTML allowance while keeping the internal marker intact.
- Reused the existing cover-palette flow from `TtsPlayer`/`ttsPrimaryColor` for the thinking treatment, so the thought text, glow, border, and block background harmonize with the post cover image instead of using a fixed accent color.
- The current text effect is a slow left-to-right gradient wave over the letters. It runs over 18 seconds and only dims to 0.92 opacity so the prose remains readable.
- The old trailing dot/pseudo-element experiment was removed; there is no rendered `::after` dot for thinking blocks.
- The block treatment resets generated paragraph margins inside the thought panel so text aligns naturally and does not appear vertically offset.
- Reduced-motion users get static readable text with animation and gradient clipping disabled.

## Files Changed

- `lib/markdown/remarkThinkingTags.ts`: new remark plugin for converting author-facing thinking tags into safe internal render markers.
- `components/blog/PostView.tsx`: plugin wiring, narrow sanitizer schema extension, cover-colored thinking styles, slow text-wave animation, block layout cleanup, and reduced-motion fallback.
- `components/blog/PostView.test.tsx`: SSR tests for inline rendering, markdown preservation, block rendering, malformed tag handling, and no-dot regression coverage.

## Testing

- `bun test components/blog/PostView.test.tsx`
- `bun run build`

Additional local Playwright validation was performed against `http://localhost:3000/blog/2026-04-28` while using temporary sample content during development. The temporary sample `<thinking>` block was removed before finalizing the PR, so no blog or lore post content currently contains thinking tokens in the branch diff.

## Notes

- Package-manager rules were followed with Bun commands only.
- This PR does not enable arbitrary raw HTML rendering. The only sanitizer change is the explicit `data-thinking` allowlist needed for the internal marker.
- Existing local dev-server console errors from `/api/tts/status` were observed during screenshot validation and appear unrelated to this change.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
