### PR TITLE
fix: repair CSS keyframe scoping, boost thinking text readability, an...

### DIFF
--- a/components/blog/PostView.tsx
+++ b/components/blog/PostView.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
+import { keyframes } from '@emotion/react';
 import {
   Box,
   Typography,
@@ -48,6 +49,39 @@ import { useDynamicBackdrop } from '@/components/DynamicBackdropProvider';
 import { AmbientCoverArt, AMBIENT_PULSE_KEYFRAMES } from '@/components/blog/AmbientCoverArt';
 import type { ParsedPost } from '../../lib/blog/parser';
 import { TtsPlayer } from './TtsPlayer';
+
+const shimmerKeyframes = keyframes({
+  '0%': { backgroundPosition: '-1000px 0' },
+  '100%': { backgroundPosition: '1000px 0' },
+});
+
+const thinkingPulseKeyframes = keyframes({
+  '0%, 100%': {
+    opacity: 0.92,
+    backgroundPosition: '160% 50%',
+    textShadow: '0 0 0 transparent',
+  },
+  '50%': {
+    opacity: 1,
+    backgroundPosition: '20% 50%',
+    textShadow: '0 0 18px var(--PostView-thinking-glow)',
+  },
+});
+
+const thinkingFloatKeyframes = keyframes({
+  '0%, 100%': { transform: 'translateY(0)' },
+  '50%': { transform: 'translateY(-3px)' },
+});
+
+const glitchFlickerKeyframes = keyframes({
+  '0%, 100%': { opacity: 1 },
+  '3%': { opacity: 0.7, transform: 'translateX(1px)' },
+  '6%': { opacity: 1, transform: 'translateX(-1px)' },
+  '9%': { opacity: 0.85, transform: 'translateX(0)' },
+  '92%': { opacity: 1 },
+  '95%': { opacity: 0.75, transform: 'translateX(-0.5px)' },
+  '98%': { opacity: 1, transform: 'translateX(0.5px)' },
+});
 
 /**
  * Props for PostView component
@@ -661,35 +695,6 @@ export function PostView({
         ) : (
           <Box
             sx={{
-              '@keyframes shimmer': {
-                '0%': { backgroundPosition: '-1000px 0' },
-                '100%': { backgroundPosition: '1000px 0' }
-              },
-              '@keyframes thinking-pulse': {
-                '0%, 100%': {
-                  opacity: 0.92,
-                  backgroundPosition: '160% 50%',
-                  textShadow: '0 0 0 transparent',
-                },
-                '50%': {
-                  opacity: 1,
-                  backgroundPosition: '20% 50%',
-                  textShadow: '0 0 18px var(--PostView-thinking-glow)',
-                },
-              },
-              '@keyframes thinking-float': {
-                '0%, 100%': { transform: 'translateY(0)' },
-                '50%': { transform: 'translateY(-3px)' },
-              },
-              '@keyframes glitch-flicker': {
-                '0%, 100%': { opacity: 1 },
-                '3%': { opacity: 0.7, transform: 'translateX(1px)' },
-                '6%': { opacity: 1, transform: 'translateX(-1px)' },
-                '9%': { opacity: 0.85, transform: 'translateX(0)' },
-                '92%': { opacity: 1 },
-                '95%': { opacity: 0.75, transform: 'translateX(-0.5px)' },
-                '98%': { opacity: 1, transform: 'translateX(0.5px)' },
-              },
               // Typography settings for readability
               fontSize: { xs: '1rem', sm: '1.125rem' }, // 16px on phones, 18px up
               lineHeight: 1.8,
@@ -772,7 +777,7 @@ export function PostView({
                 // Shimmer Effect
                 background: 'linear-gradient(to right, rgba(20, 83, 45, 0.6) 0%, rgba(74, 222, 128, 0.25) 50%, rgba(20, 83, 45, 0.6) 100%)',
                 backgroundSize: '1000px 100%',
-                animation: 'shimmer 6s linear infinite',
+                animation: `${shimmerKeyframes} 6s linear infinite`,
                 '&:nth-of-type(2n)': { animationDuration: '4s' },
                 '&:nth-of-type(3n)': { animationDuration: '8s' },
                 '&:nth-of-type(5n)': { animationDuration: '5s' },
@@ -829,7 +834,7 @@ export function PostView({
                   background: 'none !important',
                   textAlign: 'center',
                   textShadow: '1px 0 rgba(255, 0, 180, 0.4), -1px 0 rgba(0, 200, 255, 0.4)',
-                  animation: 'glitch-flicker 6s steps(1) infinite',
+                  animation: `${glitchFlickerKeyframes} 6s steps(1) infinite`,
                 },
                 '& .hljs': {
                   background: 'transparent',
@@ -864,7 +869,7 @@ export function PostView({
                 WebkitBackgroundClip: 'text',
                 backgroundClip: 'text',
                 WebkitTextFillColor: 'transparent',
-                animation: 'thinking-pulse 18s ease-in-out infinite',
+                animation: `${thinkingPulseKeyframes} 18s ease-in-out infinite`,
               },
               '& [data-thinking="inline"]': {
                 textWrap: 'pretty',
@@ -885,7 +890,7 @@ export function PostView({
                 WebkitTextFillColor: 'transparent',
                 color: 'text.primary',
                 boxShadow: `inset 0 0 28px rgba(139, 92, 246, 0.08), 0 0 32px ${thinkingGlowColor}`,
-                animation: 'thinking-float 6s ease-in-out infinite',
+                animation: `${thinkingPulseKeyframes} 18s ease-in-out infinite, ${thinkingFloatKeyframes} 6s ease-in-out infinite`,
                 '& p': { my: 0 },
                 '& p + p': { mt: 2 },
               },
@@ -918,7 +923,7 @@ export function PostView({
                 borderColor: 'rgba(255,255,255,0.1)',
                 background: 'linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.05) 50%, rgba(255, 255, 255, 0) 100%)',
                 backgroundSize: '1000px 100%',
-                animation: 'shimmer 15s linear infinite',
+                animation: `${shimmerKeyframes} 15s linear infinite`,
               },
               '& hr': {
                 border: 'none',

--- a/components/blog/PostView.tsx
+++ b/components/blog/PostView.tsx
@@ -307,7 +307,7 @@ export function PostView({
     [ttsPrimaryColor]
   );
   const thinkingColor = useMemo(
-    () => (ttsPrimaryColor ? lightenHexColor(ttsPrimaryColor, 0.2) : '#bae6fd'),
+    () => (ttsPrimaryColor ? lightenHexColor(ttsPrimaryColor, 0.45) : '#bae6fd'),
     [ttsPrimaryColor]
   );
   const thinkingGlowColor = useMemo(
@@ -378,35 +378,6 @@ export function PostView({
         mx: 'auto',
         px: { xs: 0, sm: 4 },
         py: { xs: 2.5, sm: 6 },
-        '@keyframes shimmer': {
-          '0%': { backgroundPosition: '-1000px 0' },
-          '100%': { backgroundPosition: '1000px 0' }
-        },
-        '@keyframes thinking-pulse': {
-          '0%, 100%': {
-            opacity: 0.92,
-            backgroundPosition: '160% 50%',
-            textShadow: '0 0 0 transparent',
-          },
-          '50%': {
-            opacity: 1,
-            backgroundPosition: '20% 50%',
-            textShadow: '0 0 18px var(--PostView-thinking-glow)',
-          },
-        },
-        '@keyframes thinking-float': {
-          '0%, 100%': { transform: 'translateY(0)' },
-          '50%': { transform: 'translateY(-3px)' },
-        },
-        '@keyframes glitch-flicker': {
-          '0%, 100%': { opacity: 1 },
-          '3%': { opacity: 0.7, transform: 'translateX(1px)' },
-          '6%': { opacity: 1, transform: 'translateX(-1px)' },
-          '9%': { opacity: 0.85, transform: 'translateX(0)' },
-          '92%': { opacity: 1 },
-          '95%': { opacity: 0.75, transform: 'translateX(-0.5px)' },
-          '98%': { opacity: 1, transform: 'translateX(0.5px)' },
-        },
         ...AMBIENT_PULSE_KEYFRAMES,
       }}
     >
@@ -690,6 +661,35 @@ export function PostView({
         ) : (
           <Box
             sx={{
+              '@keyframes shimmer': {
+                '0%': { backgroundPosition: '-1000px 0' },
+                '100%': { backgroundPosition: '1000px 0' }
+              },
+              '@keyframes thinking-pulse': {
+                '0%, 100%': {
+                  opacity: 0.92,
+                  backgroundPosition: '160% 50%',
+                  textShadow: '0 0 0 transparent',
+                },
+                '50%': {
+                  opacity: 1,
+                  backgroundPosition: '20% 50%',
+                  textShadow: '0 0 18px var(--PostView-thinking-glow)',
+                },
+              },
+              '@keyframes thinking-float': {
+                '0%, 100%': { transform: 'translateY(0)' },
+                '50%': { transform: 'translateY(-3px)' },
+              },
+              '@keyframes glitch-flicker': {
+                '0%, 100%': { opacity: 1 },
+                '3%': { opacity: 0.7, transform: 'translateX(1px)' },
+                '6%': { opacity: 1, transform: 'translateX(-1px)' },
+                '9%': { opacity: 0.85, transform: 'translateX(0)' },
+                '92%': { opacity: 1 },
+                '95%': { opacity: 0.75, transform: 'translateX(-0.5px)' },
+                '98%': { opacity: 1, transform: 'translateX(0.5px)' },
+              },
               // Typography settings for readability
               fontSize: { xs: '1rem', sm: '1.125rem' }, // 16px on phones, 18px up
               lineHeight: 1.8,

--- a/components/blog/PostView.tsx
+++ b/components/blog/PostView.tsx
@@ -14,7 +14,7 @@
  * - Follows MUI Joy patterns from Big-AGI
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { keyframes } from '@emotion/react';
 import {
   Box,
@@ -317,6 +317,7 @@ export function PostView({
   const { setPostCoverUrl } = useDynamicBackdrop();
   const [, setCoverIsLandscape] = useState<boolean | null>(null);
   const [ttsPrimaryColor, setTtsPrimaryColor] = useState<string | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   const dateString = useMemo(() => getPostDateString(post), [post.filename, post.metadata.date]);
   const formattedDate = useMemo(
@@ -402,6 +403,17 @@ export function PostView({
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [post.filename]);
+
+  useLayoutEffect(() => {
+    const root = contentRef.current;
+    if (!root) return;
+    root.querySelectorAll<HTMLElement>('[data-thinking]').forEach(el => {
+      el.style.animationDelay = `${-Math.random() * 30}s`;
+    });
+    root.querySelectorAll<HTMLElement>('code.language-layerone').forEach(el => {
+      el.style.animationDelay = `${-Math.random() * 10}s`;
+    });
+  }, [markdownContent]);
 
   return (
     <Box
@@ -694,6 +706,7 @@ export function PostView({
           </Card>
         ) : (
           <Box
+            ref={contentRef}
             sx={{
               // Typography settings for readability
               fontSize: { xs: '1rem', sm: '1.125rem' }, // 16px on phones, 18px up

--- a/components/blog/PostView.tsx
+++ b/components/blog/PostView.tsx
@@ -327,11 +327,11 @@ export function PostView({
     [ttsPrimaryColor]
   );
   const thinkingStrongBackground = useMemo(
-    () => hexToRgba(ttsPrimaryColor, 0.16, 'rgba(14, 116, 144, 0.16)'),
+    () => hexToRgba(ttsPrimaryColor, 0.5, 'rgba(14, 116, 144, 0.35)'),
     [ttsPrimaryColor]
   );
   const thinkingSoftBackground = useMemo(
-    () => hexToRgba(ttsPrimaryColor, 0.07, 'rgba(59, 130, 246, 0.08)'),
+    () => hexToRgba(ttsPrimaryColor, 0.25, 'rgba(59, 130, 246, 0.2)'),
     [ttsPrimaryColor]
   );
   const hasLoreStoryNavigation = postType === 'lore' && (previousStory || nextStory);
@@ -393,6 +393,19 @@ export function PostView({
             backgroundPosition: '20% 50%',
             textShadow: '0 0 18px var(--PostView-thinking-glow)',
           },
+        },
+        '@keyframes thinking-float': {
+          '0%, 100%': { transform: 'translateY(0)' },
+          '50%': { transform: 'translateY(-3px)' },
+        },
+        '@keyframes glitch-flicker': {
+          '0%, 100%': { opacity: 1 },
+          '3%': { opacity: 0.7, transform: 'translateX(1px)' },
+          '6%': { opacity: 1, transform: 'translateX(-1px)' },
+          '9%': { opacity: 0.85, transform: 'translateX(0)' },
+          '92%': { opacity: 1 },
+          '95%': { opacity: 0.75, transform: 'translateX(-0.5px)' },
+          '98%': { opacity: 1, transform: 'translateX(0.5px)' },
         },
         ...AMBIENT_PULSE_KEYFRAMES,
       }}
@@ -786,6 +799,42 @@ export function PostView({
                   background: 'transparent',
                 }
               },
+              '& pre:has(code.language-layerone)': {
+                backgroundColor: '#0d0618 !important',
+                border: '1px solid',
+                borderColor: 'rgba(0, 255, 200, 0.25)',
+                position: 'relative',
+                overflow: 'hidden',
+                my: 4,
+                p: 2,
+                borderRadius: 0,
+                textAlign: 'center',
+                '&::before': {
+                  content: '""',
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  height: '100%',
+                  background: 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0, 255, 200, 0.04) 2px, rgba(0, 255, 200, 0.04) 4px)',
+                  pointerEvents: 'none',
+                  zIndex: 1,
+                },
+                '& code.language-layerone': {
+                  backgroundColor: 'transparent !important',
+                  color: '#7fffe0',
+                  fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+                  p: 0,
+                  border: 'none',
+                  background: 'none !important',
+                  textAlign: 'center',
+                  textShadow: '1px 0 rgba(255, 0, 180, 0.4), -1px 0 rgba(0, 200, 255, 0.4)',
+                  animation: 'glitch-flicker 6s steps(1) infinite',
+                },
+                '& .hljs': {
+                  background: 'transparent',
+                },
+              },
               '& a': {
                 color: 'primary.400',
                 textDecoration: 'none',
@@ -807,8 +856,6 @@ export function PostView({
                 '--PostView-thinking-muted': thinkingMutedColor,
                 position: 'relative',
                 fontStyle: 'italic',
-              },
-              '& [data-thinking], & [data-thinking] p, & [data-thinking] li, & [data-thinking] span, & [data-thinking] strong, & [data-thinking] em, & [data-thinking] a': {
                 color: 'var(--PostView-thinking-color)',
                 background:
                   'linear-gradient(90deg, var(--PostView-thinking-muted) 0%, var(--PostView-thinking-color) 32%, rgba(255,255,255,0.96) 48%, var(--PostView-thinking-color) 64%, var(--PostView-thinking-muted) 100%)',
@@ -823,26 +870,42 @@ export function PostView({
                 textWrap: 'pretty',
               },
               '& [data-thinking="block"]': {
-                display: 'block',
-                my: 4,
-                p: { xs: 2, sm: 2.5 },
-                border: `1px solid ${thinkingSoftBorderColor}`,
-                borderLeft: `4px solid ${thinkingBorderColor}`,
-                background:
-                  `linear-gradient(135deg, ${thinkingStrongBackground}, ${thinkingSoftBackground} 45%, rgba(255, 255, 255, 0.035))`,
-                boxShadow: `inset 0 0 28px ${thinkingSoftBackground}, 0 0 24px ${thinkingSoftBackground}`,
-                '& p': {
-                  my: 0,
-                },
-                '& p + p': {
-                  mt: 2,
-                },
+                textAlign: 'center',
+                borderLeft: '4px solid',
+                borderColor: 'primary.500',
+                px: { xs: 3, sm: 4 },
+                py: 2,
+                my: 6,
+                fontStyle: 'italic',
+                backgroundColor: 'rgba(139, 92, 246, 0.05)',
+                backgroundImage: `linear-gradient(90deg, var(--PostView-thinking-muted) 0%, var(--PostView-thinking-color) 32%, rgba(255,255,255,0.96) 48%, var(--PostView-thinking-color) 64%, var(--PostView-thinking-muted) 100%), none`,
+                backgroundSize: '260% 100%, auto',
+                backgroundPosition: '160% 50%, 0 0',
+                backgroundClip: 'text, border-box',
+                WebkitTextFillColor: 'transparent',
+                color: 'text.primary',
+                boxShadow: `inset 0 0 28px rgba(139, 92, 246, 0.08), 0 0 32px ${thinkingGlowColor}`,
+                animation: 'thinking-float 6s ease-in-out infinite',
+                '& p': { my: 0 },
+                '& p + p': { mt: 2 },
               },
               '@media (prefers-reduced-motion: reduce)': {
-                '& [data-thinking], & [data-thinking] p, & [data-thinking] li, & [data-thinking] span, & [data-thinking] strong, & [data-thinking] em, & [data-thinking] a': {
+                '& [data-thinking]': {
                   animation: 'none',
                   background: 'none',
                   WebkitTextFillColor: 'currentColor',
+                },
+                '& [data-thinking="block"]': {
+                  animation: 'none',
+                  backgroundImage: 'none',
+                  backgroundClip: 'border-box',
+                  WebkitTextFillColor: 'currentColor',
+                  bgcolor: 'rgba(139, 92, 246, 0.05)',
+                },
+                '& pre code.language-layerone': {
+                  animation: 'none',
+                  textShadow: 'none',
+                  color: '#7fffe0',
                 },
               },
               '& img': {

--- a/lib/markdown/remarkThinkingTags.ts
+++ b/lib/markdown/remarkThinkingTags.ts
@@ -44,6 +44,21 @@ function createThinkingNode(variant: 'inline' | 'block', children: Content[]): T
   };
 }
 
+function isOnlyContentInParent(
+  parent: Parent,
+  openingIndex: number,
+  closingIndex: number
+): boolean {
+  for (let i = 0; i < parent.children.length; i++) {
+    if (i >= openingIndex && i <= closingIndex) continue;
+    const child = parent.children[i] as Content | undefined;
+    if (!child) continue;
+    if (child.type === 'text' && (child as any).value?.trim() !== '') return false;
+    if (child.type !== 'text') return false;
+  }
+  return true;
+}
+
 function findClosingTag(children: Content[], startIndex: number): number {
   for (let index = startIndex + 1; index < children.length; index += 1) {
     const child = children[index];
@@ -80,7 +95,9 @@ function transformParent(parent: Parent | Root): void {
       }
 
       const innerChildren = (parent.children as Content[]).slice(index + 1, closingIndex);
-      transformedChildren.push(createThinkingNode(parentIsParagraph ? 'inline' : 'block', innerChildren));
+      const isStandalone = parentIsParagraph && isOnlyContentInParent(parent, index, closingIndex);
+      const variant = !parentIsParagraph || isStandalone ? 'block' : 'inline';
+      transformedChildren.push(createThinkingNode(variant, innerChildren));
       index = closingIndex;
       continue;
     }

--- a/tts/server.py
+++ b/tts/server.py
@@ -105,6 +105,7 @@ def _clean_text(text: str) -> str:
     text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
     text = re.sub(r"\*{1,3}([^*]+)\*{1,3}", r"\1", text)
     text = re.sub(r"_{1,3}([^_]+)_{1,3}", r"\1", text)
+    text = re.sub(r"```layerone\n?([\s\S]*?)```", r"\1", text)
     text = re.sub(r"```[\s\S]*?```", "", text)
     text = re.sub(r"`([^`]+)`", r"\1", text)
     text = re.sub(r"<[^>]+>", "", text)


### PR DESCRIPTION
## Summary

Fixes four CSS `@keyframes` animations that were silently broken due to Emotion/MUI sx scoping — keyframes defined in one `<Box>`'s `sx` prop were never resolving to `animation:` references in a nested `<Box>`'s `sx`. Also improves thinking-text legibility, desyncs animation timing, and applies a dedicated visual treatment for `layerone` code blocks.

## Changes

### 1. Fix broken animations (keyframe scoping)

**Root cause:** Four `@keyframes` blocks (`shimmer`, `thinking-pulse`, `thinking-float`, `glitch-flicker`) were defined inside the outer `<Box component="article">`'s `sx` prop, but all `animation:` CSS properties referencing them lived in the inner (markdown-rendering) `<Box>`'s `sx` prop. Emotion processes each `sx` as a separate `css()` call, hashing the `@keyframes` name in the outer scope but **not** rewriting the animation name reference in the inner scope. The resulting CSS had `animation: thinking-pulse` pointing at a keyframe name that didn't exist (`thinking-pulse-abc123`), so **no animation ever ran**.

**Fix:** Migrated all four keyframe definitions from inline `@keyframes` in the `sx` object to module-level Emotion `keyframes()` helpers. This injects the keyframes globally with a stable hashed name and the `animation:` references in the `sx` prop point directly at the correct name via template literals.

### 2. Improve thinking text readability

- **`thinkingColor` lightness ratio:** increased from `0.20` → `0.45` — ensures text is legible even when `ttsPrimaryColor` is a very dark hue
- **`thinkingStrongBackground` alpha:** `0.16` → `0.50` — stronger backdrop for block-level thinking
- **`thinkingSoftBackground` alpha:** `0.07` → `0.25` — more visible soft background tint

### 3. Overhaul block-thinking (`<div data-thinking="block">`) styling

- Replaced the private `thinking-border` colors (`thinkingSoftBorderColor`, `thinkingBorderColor`) with MUI theme token `primary.500` for consistency
- Replaced the old `linear-gradient(135deg, ...)` background with the same gradient-sweep background used on inline thinking (gradient clipped to text via `background-clip: text`)
- Added `boxShadow` glow using `thinkingGlowColor`
- **Animation:** replaced the imperceptible `thinking-float` (3px `translateY` bounce over 6s) with the visible `thinking-pulse` gradient sweep + kept float as a secondary combined animation, so blocks now get both the sweep **and** a subtle float bounce

### 4. Dedicated `layerone` code block treatment

Added a new `& pre:has(code.language-layerone)` CSS block that styles `/layerone` code blocks with:
- Dark purple background (`#0d0618`) with cyan border
- Scan-line overlay via `repeating-linear-gradient` pseudo-element
- Cyan-neon text color (`#7fffe0`) with dual-tint `textShadow` (magenta/cyan)
- `glitch-flicker` animated opacity/transform vignette

### 5. Desync animation start times

Added a `useLayoutEffect` that, after markdown content renders, assigns a random negative `animationDelay` to each `[data-thinking]` element (`[-30, 0]s`) and `code.language-layerone` element (`[-10, 0]s`). This staggers the start of their animations so they don't all pulse in lockstep.

### 6. Accessibility (`prefers-reduced-motion`)

Extended the existing `@media (prefers-reduced-motion: reduce)` block to properly disable animations for:
- Inline thinking (was already handled)
- Block thinking (new — strip gradient, reset to `currentColor`)
- Layerone code blocks (new — strip glitch animation and text-shadow)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
