### PR TITLE
Add hidden blog and lore renderer test pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,9 @@
 ## Markdown Content Rules
 - In `blog/posts/*.md` and `lore/posts/*.md`, curly double quotes are banned.
 - Use straight double quotes (`"`) instead of `“` and `”`.
+
+## Content System Test Pages
+- Hidden renderer test pages live at `/blog/test` and `/lore/test`.
+- When adding or changing any user-facing blog/lore content behavior, update the relevant test page in the same change.
+- Blog test fixtures must not use lore-only `{{...}}` token systems.
+- Test pages must stay unlinked from normal navigation and content lists, and must cover representative edge cases for the affected system.

--- a/app/blog/test/page.tsx
+++ b/app/blog/test/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+import { blogRendererTestPost } from '@/lib/content/test-posts';
+
+import { PostPageClient } from '../[slug]/PostPageClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Blog Renderer Test',
+  description: 'Hidden blog renderer fixture page.',
+};
+
+export default function BlogRendererTestPage() {
+  return <PostPageClient post={blogRendererTestPost} />;
+}

--- a/app/lore/test/page.tsx
+++ b/app/lore/test/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+
+import { loreRendererTestPost } from '@/lib/content/test-posts';
+import { loadSpeciesCareCardsForMarkdown } from '@/lib/species-care/loader';
+
+import { LorePostPageClient } from '../[slug]/LorePostPageClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Lore Renderer Test',
+  description: 'Hidden lore renderer fixture page.',
+};
+
+export default async function LoreRendererTestPage() {
+  const speciesCareCards = await loadSpeciesCareCardsForMarkdown(loreRendererTestPost.content);
+
+  return <LorePostPageClient post={loreRendererTestPost} speciesCareCards={speciesCareCards} />;
+}

--- a/lib/content/test-posts.ts
+++ b/lib/content/test-posts.ts
@@ -1,0 +1,148 @@
+import type { ParsedPost } from '@/lib/blog/parser';
+
+export const blogRendererTestPost: ParsedPost = {
+  filename: 'blog-renderer-test.md',
+  metadata: {
+    title: 'Blog Renderer Test Post',
+    summary:
+      'A hidden fixture for checking standard blog metadata, markdown layout, media, and typography without entering the normal post list.',
+    tags: ['test-fixture', 'renderer', 'blog'],
+    cover_image: '/blog/placeholder.png',
+    date: '2026-05-25',
+    author: 'Midori AI Test Fixture',
+  },
+  content: `# Blog Markdown Coverage
+
+This page is a hidden renderer fixture for normal blog posts. It should cover standard markdown behavior without using lore-only brace tokens.
+
+Inline emphasis should work with **strong text**, *italic text*, inline \`code\`, and [a normal link](/blog).
+
+## Lists
+
+- First unordered item with enough text to wrap on narrow screens and prove readable spacing.
+- Second unordered item with **bold content** and inline \`values\`.
+- Third unordered item with a nested-looking phrase but no actual nested list.
+
+1. First ordered item.
+2. Second ordered item.
+3. Third ordered item.
+
+## Task List
+
+- [x] Completed renderer case.
+- [ ] Pending renderer case.
+
+## Quote
+
+> This blockquote should keep its contrast, left border, spacing, and readable line height on desktop and phone widths.
+
+## Table
+
+| Feature | Expected result |
+| --- | --- |
+| Tags | Visible chips in the header |
+| Cover image | Ambient cover art appears above content |
+| Long table text | Scrolls or wraps without causing page-level horizontal overflow |
+
+## Code
+
+\`\`\`ts
+const rendererCase = 'blog';
+const shouldStayStandardMarkdownOnly = true;
+\`\`\`
+
+\`\`\`layerone
+BLOG TEST SIGNAL :: STANDARD MARKDOWN ONLY
+\`\`\`
+
+## Image
+
+![Blog placeholder image](/blog/placeholder.png)
+
+## Dialogue And Thinking
+
+"This quoted sentence should receive dialogue styling."
+
+Text can include <thinking>short inline thinking</thinking> without breaking the paragraph.
+
+<thinking>
+This standalone thinking block should render as a larger styled block.
+</thinking>
+
+## Final Paragraph
+
+The last paragraph checks bottom spacing and confirms the post can end normally after rich content.
+`,
+  rawMarkdown: '',
+};
+
+blogRendererTestPost.rawMarkdown = blogRendererTestPost.content;
+
+export const loreRendererTestPost: ParsedPost = {
+  filename: 'lore-renderer-test.md',
+  metadata: {
+    title: 'Lore Renderer Test Post',
+    summary:
+      'A hidden fixture for checking lore metadata, lore image tokens, species cards, story styling, and markdown rendering.',
+    tags: ['lore', 'real-moments', 'test-fixture', 'luna'],
+    cover_image: '/lore/luna-lux-maboroshi.png',
+    date: '2026-05-25',
+    author: 'Midori AI Test Fixture',
+    game: 'real-moments',
+    story_order: 9999,
+    episode_label: 'Renderer Test',
+  },
+  content: `# Lore Markdown Coverage
+
+This page is a hidden renderer fixture for lore posts. It intentionally includes lore-only token systems that normal blog posts should not rely on.
+
+"Dialogue should receive the lore dialogue treatment," Luna said, checking the renderer output.
+
+## Metadata Expectations
+
+- The page should render as a lore post.
+- Tags should include lore, game, character, and fixture labels.
+- Story metadata should not require this fixture to appear in normal lore lists.
+
+## Standard Markdown
+
+| Lore system | Expected result |
+| --- | --- |
+| Markdown table | Remains readable at phone widths |
+| Links | [Back to lore](/lore) keeps normal link styling |
+| Inline code | \`story_order: 9999\` remains legible |
+
+> This blockquote checks lore prose styling in the same renderer used by real lore posts.
+
+\`\`\`layerone
+LORE TEST SIGNAL :: TOKEN SYSTEMS ACTIVE
+\`\`\`
+
+## Standard Markdown Image
+
+![WEAVE cover image](/lore/weave.png)
+
+## Lore Image Token
+
+{{image: /lore/the-story-luna-midori/01-veiled-crossing-first-shift.png}}
+
+## Species Card Token
+
+{{speciescard: /lore/luna-midori}}
+
+## Thinking Styles
+
+The line can hold <thinking>inline private-style thought</thinking> inside prose.
+
+<thinking>
+This standalone thinking block should remain visually distinct from normal narration.
+</thinking>
+
+## Closing Check
+
+The lore fixture should prove token embeds, markdown media, dialogue styling, and long-form story typography can coexist on one page.
+`,
+  rawMarkdown: '',
+};
+
+loreRendererTestPost.rawMarkdown = loreRendererTestPost.content;


### PR DESCRIPTION
## Summary

This PR adds hidden renderer test pages for the blog and lore content systems. The pages are reachable directly at `/blog/test` and `/lore/test`, but their fixture posts are code-backed instead of markdown-backed, so they do not enter the normal blog or lore loaders and cannot appear in the public content lists.

The goal is to give future content-rendering changes a stable manual verification target. When we change user-facing blog or lore behavior, the corresponding test page should be updated in the same change so regressions are easier to spot.

## Changes

Added `lib/content/test-posts.ts` with two `ParsedPost` fixtures:

- `blogRendererTestPost` covers normal blog rendering only.
- `loreRendererTestPost` covers lore rendering and lore-only token systems.

Added `app/blog/test/page.tsx`:

- Registers the hidden `/blog/test` route.
- Reuses the existing blog post rendering path through `PostPageClient`.
- Uses the shared blog test fixture.
- Includes standard metadata for the test page route.
- Keeps the blog fixture free of lore-only `{{...}}` token syntax by design.

Added `app/lore/test/page.tsx`:

- Registers the hidden `/lore/test` route.
- Reuses the existing lore post rendering path through `LorePostPageClient`.
- Uses the shared lore test fixture.
- Loads species card embed data with `loadSpeciesCareCardsForMarkdown` so the fixture exercises the existing lore species-card embed flow.
- Includes standard metadata for the test page route.

Updated `AGENTS.md` with a concise rule for keeping these pages maintained:

- Hidden renderer test pages live at `/blog/test` and `/lore/test`.
- Any user-facing blog/lore content behavior change must update the relevant test page in the same change.
- Blog test fixtures must not use lore-only `{{...}}` token systems.
- Test pages must stay unlinked from normal navigation and content lists.

## Fixture Coverage

The blog fixture covers:

- Blog title, summary, tags, cover image, date, and author metadata.
- Headings and paragraphs.
- Strong text, italic text, inline code, and links.
- Ordered and unordered lists.
- Task list markdown.
- Blockquotes.
- Tables.
- Fenced code blocks.
- `language-layerone` code styling.
- Standard markdown image rendering.
- Dialogue quote styling.
- Inline and block `<thinking>` rendering.

The lore fixture covers:

- Lore title, summary, tags, cover image, date, author, game, story order, and episode label metadata.
- Standard markdown rendering cases shared with blog posts.
- Lore image token rendering via `{{image: /lore/the-story-luna-midori/01-veiled-crossing-first-shift.png}}`.
- Species card token rendering via `{{speciescard: /lore/luna-midori}}`.
- Lore dialogue and thinking styles.
- A fixture setup that stays out of normal lore lists because it is not stored in `lore/posts`.

## Design Notes

The fixtures are intentionally stored in TypeScript rather than `blog/posts` or `lore/posts`. This keeps the test routes explicit and prevents accidental list inclusion or scheduling behavior from affecting the test pages.

The blog page intentionally does not cover `{{...}}` token systems because those are lore-only behavior. This matches the intended content boundary and avoids teaching future agents to add lore syntax to blog fixtures.

The lore test page uses a species-card token with a leading `/lore/...` path, matching the desired token style for future cleanup work.

## Validation

- Ran `bun lint`.
- `bun lint` completed and reported existing unrelated warnings in older files; no new test page files were flagged.
- Ran `bunx biome check "lib/content/test-posts.ts" "app/blog/test/page.tsx" "app/lore/test/page.tsx" "AGENTS.md"`.
- Biome checked the TypeScript route and fixture files successfully; `AGENTS.md` is ignored by the project Biome config.
- Ran `bun run build`.
- Production build completed successfully.
- Build output confirmed both `/blog/test` and `/lore/test` are registered routes.

Additional validation notes were saved to `/tmp/agents-artifacts/blog-lore-test-pages-validation.md`.

## Files Changed

- `AGENTS.md`
- `app/blog/test/page.tsx`
- `app/lore/test/page.tsx`
- `lib/content/test-posts.ts`

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
