### PR TITLE
feat: W.E.A.V.E. thinking-title glitch FX + CI build smoke test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           PORT=3000 timeout 120 bun run start &
           SERVER_PID=$!
-          trap 'kill $SERVER_PID 2>/dev/null' EXIT
+          trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
           FAILED=0
           READY=0
           for i in $(seq 1 30); do


### PR DESCRIPTION
This PR adds the W.E.A.V.E. thinking-title glitch visual effect and fixes a CI build smoke test false-positive exit code 1. The smoke test trap handler was corrected: the bash EXIT trap ran `kill $SERVER_PID 2>/dev/null` on an already-dead process, and the `kill` failure propagated as the step exit code. Added `|| true` to the trap handler to prevent this.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
