### PR TITLE
Agent Runner: You know the game picker on the left side of the lore p...

### DIFF
--- a/app/lore/[slug]/LorePostPageClient.tsx
+++ b/app/lore/[slug]/LorePostPageClient.tsx
@@ -4,8 +4,9 @@ import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
 import PasswordGate from '@/components/blog/PasswordGate';
 import { PostView } from '@/components/blog/PostView';
+import { PovPicker } from '@/components/PovPicker';
 import type { ParsedPost } from '@/lib/blog/parser';
-import type { LorePostNeighbor } from '@/lib/lore/loader';
+import type { LorePostNeighbor, PovSibling } from '@/lib/lore/loader';
 import type { SpeciesCareCardEmbedMap } from '@/lib/species-care/types';
 
 interface LorePostPageClientProps {
@@ -16,6 +17,7 @@ interface LorePostPageClientProps {
   scheduledPublishDate?: string;
   speciesCareCards?: SpeciesCareCardEmbedMap;
   gameCoverImage?: string;
+  povSiblings?: PovSibling[];
 }
 
 export function LorePostPageClient({
@@ -26,6 +28,7 @@ export function LorePostPageClient({
   scheduledPublishDate,
   speciesCareCards = {},
   gameCoverImage,
+  povSiblings,
 }: LorePostPageClientProps) {
   const router = useRouter();
   const password = post.metadata.password?.trim();
@@ -40,36 +43,39 @@ export function LorePostPageClient({
     : undefined;
 
   return (
-    <PostView
-      post={post}
-      onClose={() => router.push('/lore')}
-      backButtonLabel="Back to lore"
-      backButtonAriaLabel="Back to lore list"
-      postType="lore"
-      previousStory={
-        previousStory
-          ? {
-              href: `/lore/${previousStory.slug}`,
-              title: previousStory.post.metadata.title,
-              summary: previousStory.post.metadata.summary,
-            }
-          : null
-      }
-      nextStory={
-        nextStory
-          ? {
-              href: `/lore/${nextStory.slug}`,
-              title: nextStory.post.metadata.title,
-              summary: nextStory.post.metadata.summary,
-            }
-          : null
-      }
-      onNavigateStory={(href) => router.push(href)}
-      isScheduledPreview={isScheduledPreview}
-      scheduledPublishDate={scheduledPublishDate}
-      speciesCareCards={speciesCareCards}
-      gameCoverImage={gameCoverImage}
-      contentWrapper={contentWrapper}
-    />
+    <>
+      <PovPicker siblings={povSiblings ?? []} gameCoverImage={gameCoverImage} />
+      <PostView
+        post={post}
+        onClose={() => router.push('/lore')}
+        backButtonLabel="Back to lore"
+        backButtonAriaLabel="Back to lore list"
+        postType="lore"
+        previousStory={
+          previousStory
+            ? {
+                href: `/lore/${previousStory.slug}`,
+                title: previousStory.post.metadata.title,
+                summary: previousStory.post.metadata.summary,
+              }
+            : null
+        }
+        nextStory={
+          nextStory
+            ? {
+                href: `/lore/${nextStory.slug}`,
+                title: nextStory.post.metadata.title,
+                summary: nextStory.post.metadata.summary,
+              }
+            : null
+        }
+        onNavigateStory={(href) => router.push(href)}
+        isScheduledPreview={isScheduledPreview}
+        scheduledPublishDate={scheduledPublishDate}
+        speciesCareCards={speciesCareCards}
+        gameCoverImage={gameCoverImage}
+        contentWrapper={contentWrapper}
+      />
+    </>
   );
 }

--- a/app/lore/[slug]/page.tsx
+++ b/app/lore/[slug]/page.tsx
@@ -11,8 +11,10 @@ import { getPublishState } from '@/lib/content/publish';
 import {
   getLorePostBySlug,
   getLoreStoryNeighbors,
+  getPovSiblings,
   loadAllLorePosts,
   loadLoreGameIndexes,
+  type PovSibling,
 } from '@/lib/lore/loader';
 import { loadSpeciesCareCardsForMarkdown } from '@/lib/species-care/loader';
 
@@ -52,6 +54,12 @@ export default async function LoreEntryPage({ params }: { params: Promise<{ slug
     ? {}
     : await loadSpeciesCareCardsForMarkdown(post.content);
 
+  const rawPovSiblings = getPovSiblings(allPosts, post);
+  const povSiblings: PovSibling[] = rawPovSiblings.map((sib) => ({
+    ...sib,
+    coverImage: sib.coverImage ? transformPostImageUrl(sib.coverImage) : undefined,
+  }));
+
   return (
     <LorePostPageClient
       post={post}
@@ -61,6 +69,7 @@ export default async function LoreEntryPage({ params }: { params: Promise<{ slug
       scheduledPublishDate={publishState.publishDate ?? undefined}
       speciesCareCards={speciesCareCards}
       gameCoverImage={gameCoverImage}
+      povSiblings={povSiblings}
     />
   );
 }

--- a/components/PovPicker.tsx
+++ b/components/PovPicker.tsx
@@ -3,18 +3,18 @@
 import { keyframes } from '@emotion/react';
 import { Box, Stack, Tooltip, Typography } from '@mui/joy';
 import { useRouter } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import type { PovSibling } from '@/lib/lore/loader';
 
 const breathePulse = keyframes`
   0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.03); }
+  50% { transform: scale(1.04); }
 `;
 
 const breathePulseInverse = keyframes`
   0%, 100% { transform: scale(1); }
-  50% { transform: scale(0.97); }
+  50% { transform: scale(0.9615); }
 `;
 
 interface PovPickerProps {
@@ -41,8 +41,6 @@ export function PovPicker({ siblings, gameCoverImage }: PovPickerProps) {
     return map;
   }, [siblings]);
 
-  const [hoveredSlug, setHoveredSlug] = useState<string | null>(null);
-
   if (siblings.length === 0) return null;
 
   return (
@@ -56,22 +54,8 @@ export function PovPicker({ siblings, gameCoverImage }: PovPickerProps) {
       }}
     >
       <Stack spacing={1}>
-        <Typography
-          level="body-xs"
-          sx={{
-            color: 'rgba(255,255,255,0.5)',
-            textAlign: 'center',
-            textTransform: 'uppercase',
-            letterSpacing: '0.08em',
-            fontSize: '0.65rem',
-            mb: 0.5,
-          }}
-        >
-          Other POVs
-        </Typography>
         {siblings.map((sibling) => {
           const timing = breatheTimings.get(sibling.slug) ?? { dur: 5, delay: 0 };
-          const isHovered = hoveredSlug === sibling.slug;
           const coverUrl = sibling.coverImage ?? gameCoverImage;
 
           return (
@@ -85,16 +69,12 @@ export function PovPicker({ siblings, gameCoverImage }: PovPickerProps) {
             >
               <Box
                 onClick={() => router.push(`/lore/${sibling.slug}`)}
-                onMouseEnter={() => setHoveredSlug(sibling.slug)}
-                onMouseLeave={() => setHoveredSlug(null)}
-                onFocus={() => setHoveredSlug(sibling.slug)}
-                onBlur={() => setHoveredSlug(null)}
                 sx={{
                   position: 'relative',
                   overflow: 'hidden',
                   borderRadius: 9999,
                   width: 'auto',
-                  minWidth: 100,
+                  minWidth: 120,
                   height: 28,
                   px: 1.5,
                   cursor: 'pointer',
@@ -105,9 +85,6 @@ export function PovPicker({ siblings, gameCoverImage }: PovPickerProps) {
                   p: 0,
                   transition: 'box-shadow 0.2s ease, filter 0.2s ease',
                   ...(!coverUrl && { bgcolor: '#8b5cf6' }),
-                  ...(isHovered && {
-                    boxShadow: '0 0 0 2px rgba(255,255,255,0.9)',
-                  }),
                   '&:hover': {
                     filter: 'brightness(1.15)',
                   },
@@ -120,7 +97,7 @@ export function PovPicker({ siblings, gameCoverImage }: PovPickerProps) {
                       backgroundImage: `url(${coverUrl})`,
                       backgroundSize: 'cover',
                       backgroundPosition: 'center',
-                      filter: 'blur(6px)',
+                      filter: 'blur(8px)',
                       zIndex: 0,
                     },
                   }),
@@ -128,19 +105,11 @@ export function PovPicker({ siblings, gameCoverImage }: PovPickerProps) {
                     content: '""',
                     position: 'absolute',
                     inset: 0,
-                    bgcolor: 'rgba(0,0,0,0.38)',
+                    bgcolor: 'rgba(0,0,0,0.35)',
                     borderRadius: 9999,
                     zIndex: 1,
                   },
-                  '&:focus-visible': {
-                    outline: '2px solid',
-                    outlineColor: '#8b5cf6',
-                    outlineOffset: '2px',
-                  },
                 }}
-                tabIndex={0}
-                role="link"
-                aria-label={`${toSentenceCase(sibling.characterTag)}'s POV: ${sibling.title}`}
               >
                 <Typography
                   level="body-xs"

--- a/components/PovPicker.tsx
+++ b/components/PovPicker.tsx
@@ -3,7 +3,7 @@
 import { keyframes } from '@emotion/react';
 import { Box, Stack, Tooltip, Typography } from '@mui/joy';
 import { useRouter } from 'next/navigation';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import type { PovSibling } from '@/lib/lore/loader';
 
@@ -29,6 +29,7 @@ function toSentenceCase(value: string): string {
 
 export function PovPicker({ siblings, gameCoverImage }: PovPickerProps) {
   const router = useRouter();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const breatheTimings = useMemo(() => {
     const map = new Map<string, { dur: number; delay: number }>();
@@ -41,10 +42,34 @@ export function PovPicker({ siblings, gameCoverImage }: PovPickerProps) {
     return map;
   }, [siblings]);
 
+  useEffect(() => {
+    let prevScrollY = window.scrollY;
+    let offset = 0;
+    let rafId: number;
+
+    const frame = () => {
+      const currentScrollY = window.scrollY;
+      const delta = currentScrollY - prevScrollY;
+      offset += delta * -0.08;
+      offset *= 0.94;
+      prevScrollY = currentScrollY;
+
+      if (containerRef.current) {
+        containerRef.current.style.transform = `translateY(calc(-50% + ${offset}px))`;
+      }
+
+      rafId = requestAnimationFrame(frame);
+    };
+
+    rafId = requestAnimationFrame(frame);
+    return () => cancelAnimationFrame(rafId);
+  }, []);
+
   if (siblings.length === 0) return null;
 
   return (
     <Box
+      ref={containerRef}
       sx={{
         position: 'fixed',
         left: 16,

--- a/components/PovPicker.tsx
+++ b/components/PovPicker.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { keyframes } from '@emotion/react';
+import { Box, Stack, Tooltip, Typography } from '@mui/joy';
+import { useRouter } from 'next/navigation';
+import { useMemo, useState } from 'react';
+
+import type { PovSibling } from '@/lib/lore/loader';
+
+const breathePulse = keyframes`
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.03); }
+`;
+
+const breathePulseInverse = keyframes`
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(0.97); }
+`;
+
+interface PovPickerProps {
+  siblings: PovSibling[];
+  gameCoverImage?: string;
+}
+
+function toSentenceCase(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function PovPicker({ siblings, gameCoverImage }: PovPickerProps) {
+  const router = useRouter();
+
+  const breatheTimings = useMemo(() => {
+    const map = new Map<string, { dur: number; delay: number }>();
+    for (const sibling of siblings) {
+      map.set(sibling.slug, {
+        dur: 3.5 + Math.random() * 3,
+        delay: Math.random() * 4,
+      });
+    }
+    return map;
+  }, [siblings]);
+
+  const [hoveredSlug, setHoveredSlug] = useState<string | null>(null);
+
+  if (siblings.length === 0) return null;
+
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        left: 16,
+        top: '50%',
+        display: { xs: 'none', xl: 'flex' },
+        zIndex: 1000,
+      }}
+    >
+      <Stack spacing={1}>
+        <Typography
+          level="body-xs"
+          sx={{
+            color: 'rgba(255,255,255,0.5)',
+            textAlign: 'center',
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            fontSize: '0.65rem',
+            mb: 0.5,
+          }}
+        >
+          Other POVs
+        </Typography>
+        {siblings.map((sibling) => {
+          const timing = breatheTimings.get(sibling.slug) ?? { dur: 5, delay: 0 };
+          const isHovered = hoveredSlug === sibling.slug;
+          const coverUrl = sibling.coverImage ?? gameCoverImage;
+
+          return (
+            <Tooltip
+              key={sibling.slug}
+              arrow
+              variant="soft"
+              title={sibling.title}
+              placement="right"
+              enterTouchDelay={0}
+            >
+              <Box
+                onClick={() => router.push(`/lore/${sibling.slug}`)}
+                onMouseEnter={() => setHoveredSlug(sibling.slug)}
+                onMouseLeave={() => setHoveredSlug(null)}
+                onFocus={() => setHoveredSlug(sibling.slug)}
+                onBlur={() => setHoveredSlug(null)}
+                sx={{
+                  position: 'relative',
+                  overflow: 'hidden',
+                  borderRadius: 9999,
+                  width: 'auto',
+                  minWidth: 100,
+                  height: 28,
+                  px: 1.5,
+                  cursor: 'pointer',
+                  whiteSpace: 'nowrap',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  p: 0,
+                  transition: 'box-shadow 0.2s ease, filter 0.2s ease',
+                  ...(!coverUrl && { bgcolor: '#8b5cf6' }),
+                  ...(isHovered && {
+                    boxShadow: '0 0 0 2px rgba(255,255,255,0.9)',
+                  }),
+                  '&:hover': {
+                    filter: 'brightness(1.15)',
+                  },
+                  animation: `${breathePulse} ${timing.dur}s ease-in-out ${timing.delay}s infinite`,
+                  ...(coverUrl && {
+                    '&::before': {
+                      content: '""',
+                      position: 'absolute',
+                      inset: -4,
+                      backgroundImage: `url(${coverUrl})`,
+                      backgroundSize: 'cover',
+                      backgroundPosition: 'center',
+                      filter: 'blur(6px)',
+                      zIndex: 0,
+                    },
+                  }),
+                  '&::after': {
+                    content: '""',
+                    position: 'absolute',
+                    inset: 0,
+                    bgcolor: 'rgba(0,0,0,0.38)',
+                    borderRadius: 9999,
+                    zIndex: 1,
+                  },
+                  '&:focus-visible': {
+                    outline: '2px solid',
+                    outlineColor: '#8b5cf6',
+                    outlineOffset: '2px',
+                  },
+                }}
+                tabIndex={0}
+                role="link"
+                aria-label={`${toSentenceCase(sibling.characterTag)}'s POV: ${sibling.title}`}
+              >
+                <Typography
+                  level="body-xs"
+                  sx={{
+                    position: 'relative',
+                    zIndex: 2,
+                    color: 'common.white',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    animation: `${breathePulseInverse} ${timing.dur}s ease-in-out ${timing.delay}s infinite`,
+                  }}
+                >
+                  {toSentenceCase(sibling.characterTag)}
+                </Typography>
+              </Box>
+            </Tooltip>
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+}

--- a/lib/lore/loader.ts
+++ b/lib/lore/loader.ts
@@ -52,6 +52,13 @@ export interface LoreGameGroup {
 
 export type LorePostSortMode = 'story_order_desc' | 'story_order_asc' | 'date_desc' | 'date_asc';
 
+export interface PovSibling {
+  slug: string;
+  title: string;
+  characterTag: string;
+  coverImage: string | undefined;
+}
+
 export interface LorePostNeighbor {
   post: ParsedPost;
   slug: string;
@@ -300,6 +307,71 @@ export function getLorePostsForGame(posts: ParsedPost[], gameSlug: string): Pars
   const normalizedGame = normalizeSlug(gameSlug);
   if (!normalizedGame) return [];
   return posts.filter((post) => normalizeSlug(post.metadata.game) === normalizedGame);
+}
+
+export function getPovSiblings(allPosts: ParsedPost[], currentPost: ParsedPost): PovSibling[] {
+  const gameSlug = normalizeSlug(currentPost.metadata.game);
+  const storyOrder = getStoryOrderValue(currentPost);
+
+  if (!gameSlug || storyOrder === null) return [];
+
+  const currentTags = new Set(getPostCharacterTags(currentPost, gameSlug));
+  const gamePosts = getLorePostsForGame(allPosts, gameSlug);
+  const currentEpisode = currentPost.metadata.episode_label?.trim().toLowerCase() || null;
+
+  const byCharacter = new Map<string, ParsedPost[]>();
+
+  for (const post of gamePosts) {
+    if (post.filename === currentPost.filename) continue;
+
+    const tags = getPostCharacterTags(post, gameSlug);
+    if (tags.length === 0) continue;
+
+    const primaryTag = (tags[0] ?? '').toLowerCase();
+    if (currentTags.has(primaryTag)) continue;
+
+    const bucket = byCharacter.get(primaryTag) ?? [];
+    bucket.push(post);
+    byCharacter.set(primaryTag, bucket);
+  }
+
+  const siblings: PovSibling[] = [];
+
+  for (const [characterTag, posts] of byCharacter) {
+    const withOrder = posts.map((p) => ({
+      post: p,
+      order: getStoryOrderValue(p),
+    }));
+
+    withOrder.sort((a, b) => {
+      const distA = a.order !== null ? Math.abs(a.order - storyOrder) : Number.MAX_SAFE_INTEGER;
+      const distB = b.order !== null ? Math.abs(b.order - storyOrder) : Number.MAX_SAFE_INTEGER;
+      if (distA !== distB) return distA - distB;
+
+      // Tiebreaker: prefer same episode_label
+      const aEpisode = a.post.metadata.episode_label?.trim().toLowerCase() || null;
+      const bEpisode = b.post.metadata.episode_label?.trim().toLowerCase() || null;
+      const aSame = aEpisode === currentEpisode ? 0 : 1;
+      const bSame = bEpisode === currentEpisode ? 0 : 1;
+      if (aSame !== bSame) return aSame - bSame;
+
+      return a.post.filename.localeCompare(b.post.filename);
+    });
+
+    const closest = withOrder[0]?.post;
+    if (!closest) continue;
+    siblings.push({
+      slug: getLorePostSlug(closest),
+      title: closest.metadata.title,
+      characterTag:
+        closest.metadata.tags?.find((t) => t.trim().toLowerCase() === characterTag) ?? characterTag,
+      coverImage: closest.metadata.cover_image?.trim() || undefined,
+    });
+  }
+
+  siblings.sort((a, b) => a.characterTag.localeCompare(b.characterTag));
+
+  return siblings;
 }
 
 export async function loadAllLorePosts(

--- a/lib/lore/loader.ts
+++ b/lib/lore/loader.ts
@@ -315,6 +315,7 @@ export function getPovSiblings(allPosts: ParsedPost[], currentPost: ParsedPost):
 
   if (!gameSlug || storyOrder === null) return [];
 
+  const currentFilename = currentPost.filename;
   const currentTags = new Set(getPostCharacterTags(currentPost, gameSlug));
   const gamePosts = getLorePostsForGame(allPosts, gameSlug);
   const currentEpisode = currentPost.metadata.episode_label?.trim().toLowerCase() || null;
@@ -341,14 +342,21 @@ export function getPovSiblings(allPosts: ParsedPost[], currentPost: ParsedPost):
     const withOrder = posts.map((p) => ({
       post: p,
       order: getStoryOrderValue(p),
+      sharedSuffixLen: commonSuffixLength(currentFilename, p.filename),
     }));
 
     withOrder.sort((a, b) => {
+      // Primary: prefer same sub-chapter (longer shared filename suffix)
+      if (a.sharedSuffixLen !== b.sharedSuffixLen) {
+        return b.sharedSuffixLen - a.sharedSuffixLen;
+      }
+
+      // Secondary: story_order proximity
       const distA = a.order !== null ? Math.abs(a.order - storyOrder) : Number.MAX_SAFE_INTEGER;
       const distB = b.order !== null ? Math.abs(b.order - storyOrder) : Number.MAX_SAFE_INTEGER;
       if (distA !== distB) return distA - distB;
 
-      // Tiebreaker: prefer same episode_label
+      // Tertiary: prefer same episode_label
       const aEpisode = a.post.metadata.episode_label?.trim().toLowerCase() || null;
       const bEpisode = b.post.metadata.episode_label?.trim().toLowerCase() || null;
       const aSame = aEpisode === currentEpisode ? 0 : 1;
@@ -372,6 +380,18 @@ export function getPovSiblings(allPosts: ParsedPost[], currentPost: ParsedPost):
   siblings.sort((a, b) => a.characterTag.localeCompare(b.characterTag));
 
   return siblings;
+}
+
+function commonSuffixLength(a: string, b: string): number {
+  let i = a.length - 1;
+  let j = b.length - 1;
+  let len = 0;
+  while (i >= 0 && j >= 0 && a[i] === b[j]) {
+    len++;
+    i--;
+    j--;
+  }
+  return len;
 }
 
 export async function loadAllLorePosts(


### PR DESCRIPTION
Automated by [Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner).

Agent: [OpenCode](https://github.com/anomalyco/opencode)

Task: 9913095948

Prompt:
You know the game picker on the left side of the lore page? Could we add the POV's for the same game to that for the lore posts themself? IE if the user is reading Luna's in real moments, then the others that have povs for that post will show up on the left (Luna's will not)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
