### PR TITLE
fix: add ffmpeg to Dockerfile for radio probe metadata extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN yay -Syu --noconfirm unzip && yay -Yccc --noconfirm
 RUN yay -Syu --noconfirm npm && yay -Yccc --noconfirm
 RUN yay -Syu --noconfirm bun && yay -Yccc --noconfirm
 RUN yay -Syu --noconfirm espeak-ng && yay -Yccc --noconfirm
+RUN yay -Syu --noconfirm ffmpeg && yay -Yccc --noconfirm
 RUN yay -Syu --noconfirm uv && yay -Yccc --noconfirm
 
 WORKDIR /app


### PR DESCRIPTION
The radio probe endpoint (`/api/radio/probe`) uses `ffprobe` to extract track metadata (artist, comment, backstory, etc.) from the audio stream. `ffprobe` is part of the `ffmpeg` package, which was not installed in the Docker image. This caused every probe request to return `ok: false` with `RADIO_PROBE_FAILED`, and the "Track Story" section showed the static fallback text instead of actual metadata.

Added `ffmpeg` package install to the Dockerfile.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
