### PR TITLE
Fix: radio channel change restart + audio crossfade + widget/page han...

### DIFF
--- a/app/radio/RadioPageClient.tsx
+++ b/app/radio/RadioPageClient.tsx
@@ -149,6 +149,33 @@ function getStreamStateLabel(streamState: StreamState): string {
   return 'Idle';
 }
 
+function fadeAudioVolume(
+  audio: HTMLAudioElement,
+  from: number,
+  to: number,
+  durationMs: number,
+): Promise<void> {
+  if (durationMs <= 0) {
+    audio.volume = to;
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const start = performance.now();
+    const step = () => {
+      const elapsed = performance.now() - start;
+      const progress = Math.min(elapsed / durationMs, 1);
+      const eased = 1 - (1 - progress) ** 3;
+      audio.volume = Math.min(1, Math.max(0, from + (to - from) * eased));
+      if (progress < 1) {
+        requestAnimationFrame(step);
+      } else {
+        resolve();
+      }
+    };
+    requestAnimationFrame(step);
+  });
+}
+
 export default function RadioPageClient() {
   const audioRef = React.useRef<HTMLAudioElement | null>(null);
   const channelRef = React.useRef('all');
@@ -176,6 +203,8 @@ export default function RadioPageClient() {
   const [playbackDesired, setPlaybackDesired] = React.useState(false);
   const [streamState, setStreamState] = React.useState<StreamState>('idle');
   const [restartNonce, setRestartNonce] = React.useState(0);
+  const prevChannelRef = React.useRef(channel);
+  const restoreInitialRef = React.useRef(true);
 
   const [channels, setChannels] = React.useState<ChannelEntry[]>([]);
   const [listenerCount, setListenerCount] = React.useState<number | null>(null);
@@ -635,6 +664,43 @@ export default function RadioPageClient() {
   React.useEffect(() => {
     startPlaybackRef.current = startPlayback;
   }, [startPlayback]);
+
+  React.useEffect(() => {
+    if (!hydrated) return;
+    if (prevChannelRef.current === channel) return;
+    prevChannelRef.current = channel;
+
+    if (!playbackDesiredRef.current) return;
+
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    const userVolume = volumeRef.current;
+
+    const doChannelSwitch = async () => {
+      await fadeAudioVolume(audio, userVolume, 0, 500);
+      stopPlayback();
+      startPlayback();
+      await new Promise((r) => setTimeout(r, 50));
+      const newAudio = audioRef.current;
+      if (newAudio) {
+        await fadeAudioVolume(newAudio, 0, userVolume, 500);
+      }
+    };
+
+    void doChannelSwitch();
+  }, [channel, hydrated, stopPlayback, startPlayback]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional one-shot hydration effect
+  React.useEffect(() => {
+    if (!hydrated) return;
+    if (!restoreInitialRef.current) return;
+    restoreInitialRef.current = false;
+    const restored = loadRadioState();
+    if (restored.playing) {
+      startPlayback();
+    }
+  }, [hydrated]);
 
   React.useEffect(() => {
     const audio = new Audio();

--- a/components/radio/RadioWidget.tsx
+++ b/components/radio/RadioWidget.tsx
@@ -28,6 +28,7 @@ import {
   clearRadioLastError,
   loadRadioState,
   MIDORIAI_RADIO_CHANNEL_KEY,
+  MIDORIAI_RADIO_PLAYING_KEY,
   MIDORIAI_RADIO_QUALITY_KEY,
   MIDORIAI_RADIO_STATE_EVENT,
   MIDORIAI_RADIO_VOLUME_KEY,
@@ -35,6 +36,7 @@ import {
   saveRadioChannel,
   saveRadioLastError,
   saveRadioOpen,
+  saveRadioPlaying,
   saveRadioQuality,
   saveRadioVolume,
 } from '@/lib/radio/state';
@@ -187,6 +189,7 @@ export default function RadioWidget() {
     setQuality(restored.quality);
     setChannel(normalizeChannel(restored.channel));
     setLastError(restored.lastError);
+    setPlaybackDesired(restored.playing);
     setHydrated(true);
   }, []);
 
@@ -208,6 +211,12 @@ export default function RadioWidget() {
 
       if (detail.key === MIDORIAI_RADIO_CHANNEL_KEY) {
         setChannel(normalizeChannel(detail.value));
+        return;
+      }
+
+      if (detail.key === MIDORIAI_RADIO_PLAYING_KEY) {
+        setPlaybackDesired(detail.value === 'true');
+        return;
       }
     };
 
@@ -266,6 +275,11 @@ export default function RadioWidget() {
     }
     saveRadioVolume(clamped);
   }, [volume, hydrated]);
+
+  React.useEffect(() => {
+    if (!hydrated) return;
+    saveRadioPlaying(playbackDesired);
+  }, [playbackDesired, hydrated]);
 
   const clearCloseLingerTimer = React.useCallback(() => {
     if (closeLingerTimerRef.current !== null) {
@@ -331,6 +345,15 @@ export default function RadioWidget() {
       }
     });
   }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional one-shot hydration effect
+  React.useEffect(() => {
+    if (!hydrated) return;
+    const restored = loadRadioState();
+    if (restored.playing) {
+      startPlayback();
+    }
+  }, [hydrated]);
 
   const scheduleReconnect = React.useCallback(() => {
     if (!playbackDesiredRef.current) {

--- a/components/radio/RadioWidget.tsx
+++ b/components/radio/RadioWidget.tsx
@@ -355,6 +355,29 @@ export default function RadioWidget() {
     }
   }, [hydrated]);
 
+  React.useEffect(() => {
+    if (!hydrated) return;
+
+    if (isRadioPage) {
+      if (playbackDesiredRef.current) {
+        playbackDesiredRef.current = false;
+        const audio = audioRef.current;
+        if (audio !== null) {
+          audio.pause();
+          audio.removeAttribute('src');
+          audio.load();
+        }
+        setStreamState('idle');
+        setStatusText('Stopped');
+      }
+    } else {
+      const restored = loadRadioState();
+      if (restored.playing) {
+        startPlayback();
+      }
+    }
+  }, [isRadioPage, hydrated, startPlayback]);
+
   const scheduleReconnect = React.useCallback(() => {
     if (!playbackDesiredRef.current) {
       return;


### PR DESCRIPTION
- **RadioPageClient**: channel changes now fade out audio, restart the stream with the new channel, then fade back in (500ms crossfade). Auto-resumes playback when navigating to `/radio` if the widget was playing.
- **RadioWidget**: now persists and syncs `playing` state via localStorage, enabling bidirectional handoff with the radio page. Auto-resumes playback on hydration if it was previously playing.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
