### PR TITLE
feat(radio): add desktop lyrics panel with palette-colored section la...

### DIFF
--- a/app/radio/RadioPageClient.tsx
+++ b/app/radio/RadioPageClient.tsx
@@ -53,6 +53,33 @@ const fadeIn = keyframes`
   to { opacity: 1; }
 `;
 
+const lyricsEnterRise = keyframes`
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+`;
+
+const lyricsExitDrop = keyframes`
+  from { opacity: 1; transform: translateY(0); }
+  to { opacity: 0; transform: translateY(-8px); }
+`;
+
+const lyricsFadeOnly = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`;
+
+const lyricsFadeOutOnly = keyframes`
+  from { opacity: 1; }
+  to { opacity: 0; }
+`;
+
+const borderGlow = keyframes`
+  0% { border-color: rgba(139, 92, 246, 0.45); }
+  20% { border-color: rgba(139, 92, 246, 0.28); }
+  55% { border-color: rgba(139, 92, 246, 0.10); }
+  100% { border-color: rgba(255, 255, 255, 0.08); }
+`;
+
 type StreamState = 'idle' | 'loading' | 'playing' | 'error';
 
 interface ProbeMetadata {
@@ -222,13 +249,42 @@ export default function RadioPageClient() {
   const [mobileVolOpen, setMobileVolOpen] = React.useState(false);
   const volLeaveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const mobileVolRef = React.useRef<HTMLDivElement | null>(null);
+
+  // ── Lyrics panel animation state ──
+  const LYRICS_ANIM_MS = 350;
+  const LYRICS_ANIM_REDUCED_MS = 150;
+  const [reducedMotion, setReducedMotion] = React.useState(false);
+  const [lyricsMounted, setLyricsMounted] = React.useState(false);
+  const [lyricsExpanded, setLyricsExpanded] = React.useState(false);
+  const [lyricsEnterKey, setLyricsEnterKey] = React.useState(0);
+  const [lyricsContent, setLyricsContent] = React.useState<string | null>(null);
+  const [lyricsScrollTop, setLyricsScrollTop] = React.useState(false);
+  const [lyricsScrollBottom, setLyricsScrollBottom] = React.useState(false);
+  const lyricsPhaseRef = React.useRef<'hidden' | 'entering' | 'visible' | 'exiting'>('hidden');
+  const lyricsTrackIdRef = React.useRef<string | null>(null);
+  const lyricsTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingLyricsRef = React.useRef<{ content: string; trackId: string } | null>(null);
+  const lyricsScrollRef = React.useRef<HTMLDivElement | null>(null);
+  const currentLyricsTargetRef = React.useRef<string | null>(null);
+
   const currentTrackId = currentTrack?.track_id ?? null;
+  // Keep target ref in sync for lyrics timer callbacks
+  currentLyricsTargetRef.current = currentTrackId;
 
   React.useEffect(() => {
     document.body.style.overflow = 'hidden';
     return () => {
       document.body.style.overflow = '';
     };
+  }, []);
+
+  // ── Reduced motion detection ──
+  React.useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReducedMotion(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
   }, []);
 
   React.useEffect(() => {
@@ -619,6 +675,150 @@ export default function RadioPageClient() {
     };
   }, [channel, currentTrackId, hydrated]);
 
+  // ── Cleanup lyrics timer on unmount ──
+  React.useEffect(() => {
+    return () => {
+      if (lyricsTimerRef.current !== null) {
+        clearTimeout(lyricsTimerRef.current);
+      }
+    };
+  }, []);
+
+  // ── Lyrics panel lifecycle ──
+  React.useEffect(() => {
+    const trackId = currentTrackId;
+    const animDuration = reducedMotion ? LYRICS_ANIM_REDUCED_MS : LYRICS_ANIM_MS;
+
+    const clearTimer = () => {
+      if (lyricsTimerRef.current !== null) {
+        clearTimeout(lyricsTimerRef.current);
+        lyricsTimerRef.current = null;
+      }
+    };
+
+    const performEnter = (content: string, tid: string) => {
+      lyricsPhaseRef.current = 'entering';
+      lyricsTrackIdRef.current = tid;
+      pendingLyricsRef.current = null;
+      setLyricsContent(content);
+      setLyricsMounted(true);
+      setLyricsExpanded(false);
+
+      clearTimer();
+      // rAF delay so the initial collapsed render paints before expansion
+      lyricsTimerRef.current = setTimeout(() => {
+        setLyricsExpanded(true);
+        setLyricsEnterKey((k) => k + 1);
+
+        lyricsTimerRef.current = setTimeout(() => {
+          lyricsPhaseRef.current = 'visible';
+        }, animDuration);
+      }, 16);
+    };
+
+    const performExit = () => {
+      lyricsPhaseRef.current = 'exiting';
+      clearTimer();
+      setLyricsExpanded(false);
+
+      lyricsTimerRef.current = setTimeout(() => {
+        lyricsPhaseRef.current = 'hidden';
+        lyricsTrackIdRef.current = null;
+        setLyricsMounted(false);
+        setLyricsContent(null);
+
+        const pending = pendingLyricsRef.current;
+        if (pending !== null && pending.trackId === currentLyricsTargetRef.current) {
+          lyricsTimerRef.current = setTimeout(() => {
+            performEnter(pending.content, pending.trackId);
+          }, 30);
+        }
+      }, animDuration);
+    };
+
+    // No track — reset everything
+    if (trackId === null) {
+      if (lyricsPhaseRef.current !== 'hidden') {
+        performExit();
+      }
+      return;
+    }
+
+    const hasValidLyrics = !!(
+      probeData?.ok &&
+      (probeData?.lyricsEng ?? '').trim() &&
+      (probeData?.lyricsEng ?? '').trim() !== '[Instrumental]'
+    );
+    const newContent = hasValidLyrics ? (probeData?.lyricsEng ?? '').trim() : null;
+
+    const phase = lyricsPhaseRef.current;
+    const currentLyricsTrack = lyricsTrackIdRef.current;
+
+    // Track changed away from our currently displayed lyrics
+    if (currentLyricsTrack !== null && currentLyricsTrack !== trackId) {
+      if (phase === 'visible' || phase === 'entering') {
+        pendingLyricsRef.current = null;
+        performExit();
+      }
+      return;
+    }
+
+    // Same track — only react if lyrics became invalid (e.g. switched to instrumental)
+    if (currentLyricsTrack === trackId) {
+      if (!probeLoading && newContent === null && phase === 'visible') {
+        performExit();
+      }
+      return;
+    }
+
+    // No lyrics currently displayed for this track
+    if (!probeLoading) {
+      if (newContent === null) {
+        if (phase === 'visible' || phase === 'entering') {
+          performExit();
+        }
+        return;
+      }
+
+      // Valid lyrics — if currently exiting, store as pending
+      if (phase === 'exiting') {
+        pendingLyricsRef.current = { content: newContent, trackId };
+        return;
+      }
+
+      if (phase === 'hidden') {
+        performEnter(newContent, trackId);
+      }
+    }
+  }, [currentTrackId, probeData, probeLoading, reducedMotion]);
+
+  // ── Scroll edge-fade detection ──
+  React.useEffect(() => {
+    if (!lyricsMounted) return;
+    const el = lyricsScrollRef.current;
+    if (!el) return;
+
+    const check = () => {
+      if (!lyricsScrollRef.current) return;
+      const s = lyricsScrollRef.current;
+      setLyricsScrollTop(s.scrollTop > 2);
+      setLyricsScrollBottom(s.scrollTop + s.clientHeight < s.scrollHeight - 2);
+    };
+
+    check();
+    // Re-check after enter animation settles; lyricsEnterKey bump drives the retrigger
+    void lyricsEnterKey;
+    const timer = setTimeout(check, 400);
+    return () => clearTimeout(timer);
+  }, [lyricsEnterKey, lyricsMounted]);
+
+  const handleLyricsScroll = React.useCallback(() => {
+    const el = lyricsScrollRef.current;
+    if (!el) return;
+    setLyricsScrollTop(el.scrollTop > 2);
+    setLyricsScrollBottom(el.scrollTop + el.clientHeight < el.scrollHeight - 2);
+  }, []);
+
   const startPlayback = React.useCallback(() => {
     const audio = audioRef.current;
     if (audio === null) {
@@ -880,9 +1080,6 @@ export default function RadioPageClient() {
   const artist = probeData?.artist?.trim() || 'Midori AI';
   const title = currentTrack?.title ?? 'Finding current track…';
   const streamStateLabel = getStreamStateLabel(streamState);
-
-  const lyricsText = (probeData?.lyricsEng ?? '').trim();
-  const showLyrics = !!(probeData?.ok && lyricsText && lyricsText !== '[Instrumental]');
 
   const volumeDots = React.useMemo(
     () =>
@@ -1217,53 +1414,121 @@ export default function RadioPageClient() {
                 )}
               </Box>
             </Sheet>
-            {showLyrics ? (
-              <Sheet
-                variant="outlined"
+            {lyricsMounted ? (
+              <Box
                 sx={{
-                  display: { xs: 'none', md: 'flex' },
-                  flexDirection: 'column',
+                  display: { xs: 'none', md: 'block' },
+                  maxHeight: lyricsExpanded ? '40vh' : '0px',
+                  overflow: 'hidden',
+                  transition: `max-height ${reducedMotion ? LYRICS_ANIM_REDUCED_MS : LYRICS_ANIM_MS}ms ease-out`,
                   mt: 1,
-                  maxHeight: '40%',
-                  overflow: 'auto',
-                  px: 2,
-                  py: 1.5,
-                  bgcolor: 'rgba(10,12,18,0.4)',
-                  borderColor: 'rgba(255,255,255,0.08)',
-                  borderRadius: 0,
                 }}
               >
-                <Typography
-                  level="body-sm"
+                <Sheet
+                  variant="outlined"
                   sx={{
-                    color: 'text.tertiary',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.06em',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    height: '40vh',
+                    bgcolor: 'rgba(10,12,18,0.4)',
+                    borderColor: 'rgba(255,255,255,0.08)',
+                    borderRadius: 0,
+                    position: 'relative',
+                    animation:
+                      lyricsExpanded && lyricsEnterKey > 0
+                        ? reducedMotion
+                          ? 'none'
+                          : `${borderGlow} 1.2s ease-out`
+                        : 'none',
                   }}
                 >
-                  Lyrics
-                </Typography>
-                <Box
-                  key={currentTrackId ?? 'idle'}
-                  sx={{ mt: 1, animation: `${fadeIn} 0.35s ease-out` }}
-                >
-                  {lyricsText ? (
+                  <Box sx={{ px: 2, pt: 1.5, pb: 0.5, flexShrink: 0 }}>
                     <Typography
                       level="body-sm"
-                      sx={{ whiteSpace: 'pre-wrap', color: 'text.secondary' }}
+                      sx={{
+                        color: 'text.tertiary',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.06em',
+                      }}
                     >
-                      {lyricsText}
+                      Lyrics
                     </Typography>
-                  ) : probeLoading ? (
-                    <Stack spacing={1}>
-                      <Skeleton variant="text" width="90%" />
-                      <Skeleton variant="text" width="75%" />
-                      <Skeleton variant="text" width="85%" />
-                      <Skeleton variant="text" width="60%" />
-                    </Stack>
-                  ) : null}
-                </Box>
-              </Sheet>
+                  </Box>
+                  <Box
+                    sx={{
+                      position: 'relative',
+                      flex: 1,
+                      minHeight: 0,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    {lyricsScrollTop && (
+                      <Box
+                        aria-hidden
+                        sx={{
+                          position: 'absolute',
+                          top: 0,
+                          left: 0,
+                          right: 0,
+                          height: 28,
+                          zIndex: 1,
+                          background:
+                            'linear-gradient(to bottom, rgba(10,12,18,0.95), transparent)',
+                          pointerEvents: 'none',
+                        }}
+                      />
+                    )}
+                    <Box
+                      ref={lyricsScrollRef}
+                      onScroll={handleLyricsScroll}
+                      sx={{
+                        overflow: 'auto',
+                        height: '100%',
+                        px: 2,
+                        pb: 2,
+                      }}
+                    >
+                      <Box
+                        key={lyricsEnterKey}
+                        sx={{
+                          animation:
+                            lyricsMounted && !lyricsExpanded
+                              ? reducedMotion
+                                ? `${lyricsFadeOutOnly} ${LYRICS_ANIM_REDUCED_MS}ms ease-out`
+                                : `${lyricsExitDrop} ${LYRICS_ANIM_MS}ms ease-out`
+                              : lyricsExpanded && lyricsEnterKey > 0
+                                ? reducedMotion
+                                  ? `${lyricsFadeOnly} ${LYRICS_ANIM_REDUCED_MS}ms ease-out`
+                                  : `${lyricsEnterRise} ${LYRICS_ANIM_MS}ms ease-out`
+                                : 'none',
+                        }}
+                      >
+                        <Typography
+                          level="body-sm"
+                          sx={{ whiteSpace: 'pre-wrap', color: 'text.secondary' }}
+                        >
+                          {lyricsContent}
+                        </Typography>
+                      </Box>
+                    </Box>
+                    {lyricsScrollBottom && (
+                      <Box
+                        aria-hidden
+                        sx={{
+                          position: 'absolute',
+                          bottom: 0,
+                          left: 0,
+                          right: 0,
+                          height: 28,
+                          zIndex: 1,
+                          background: 'linear-gradient(to top, rgba(10,12,18,0.95), transparent)',
+                          pointerEvents: 'none',
+                        }}
+                      />
+                    )}
+                  </Box>
+                </Sheet>
+              </Box>
             ) : null}
           </Stack>
         </Stack>

--- a/app/radio/RadioPageClient.tsx
+++ b/app/radio/RadioPageClient.tsx
@@ -882,7 +882,7 @@ export default function RadioPageClient() {
   const streamStateLabel = getStreamStateLabel(streamState);
 
   const lyricsText = (probeData?.lyricsEng ?? '').trim();
-  const showLyrics = !!(probeData?.ok && lyricsText && !lyricsText.includes('[Instrumental]'));
+  const showLyrics = !!(probeData?.ok && lyricsText && lyricsText !== '[Instrumental]');
 
   const volumeDots = React.useMemo(
     () =>

--- a/app/radio/RadioPageClient.tsx
+++ b/app/radio/RadioPageClient.tsx
@@ -1453,7 +1453,7 @@ export default function RadioPageClient() {
               <Box
                 sx={{
                   display: { xs: 'none', md: 'block' },
-                  maxHeight: lyricsExpanded ? '40vh' : '0px',
+                  maxHeight: lyricsExpanded ? '70vh' : '0px',
                   overflow: 'hidden',
                   transition: `max-height ${reducedMotion ? LYRICS_ANIM_REDUCED_MS : LYRICS_ANIM_MS}ms ease-out`,
                   mt: 1,
@@ -1464,7 +1464,7 @@ export default function RadioPageClient() {
                   sx={{
                     display: 'flex',
                     flexDirection: 'column',
-                    height: '40vh',
+                    height: '70vh',
                     bgcolor: 'rgba(10,12,18,0.4)',
                     borderColor: 'rgba(255,255,255,0.08)',
                     borderRadius: 0,

--- a/app/radio/RadioPageClient.tsx
+++ b/app/radio/RadioPageClient.tsx
@@ -1453,7 +1453,7 @@ export default function RadioPageClient() {
               <Box
                 sx={{
                   display: { xs: 'none', md: 'block' },
-                  maxHeight: lyricsExpanded ? '70vh' : '0px',
+                  maxHeight: lyricsExpanded ? '60vh' : '0px',
                   overflow: 'hidden',
                   transition: `max-height ${reducedMotion ? LYRICS_ANIM_REDUCED_MS : LYRICS_ANIM_MS}ms ease-out`,
                   mt: 1,
@@ -1464,7 +1464,7 @@ export default function RadioPageClient() {
                   sx={{
                     display: 'flex',
                     flexDirection: 'column',
-                    height: '70vh',
+                    height: '60vh',
                     bgcolor: 'rgba(10,12,18,0.4)',
                     borderColor: 'rgba(255,255,255,0.08)',
                     borderRadius: 0,

--- a/app/radio/RadioPageClient.tsx
+++ b/app/radio/RadioPageClient.tsx
@@ -1548,7 +1548,10 @@ export default function RadioPageClient() {
                             const glowColor = `${pickPaletteHex(labelIdx + 1, artPalette)}40`;
                             return (
                               <Typography
-                                key={i}
+                                key={
+                                  // biome-ignore lint/suspicious/noArrayIndexKey: static lyrics list won't be reordered
+                                  i
+                                }
                                 level="body-sm"
                                 sx={{
                                   color: labelColor,
@@ -1566,10 +1569,14 @@ export default function RadioPageClient() {
                             );
                           }
                           return line === '' ? (
+                            // biome-ignore lint/suspicious/noArrayIndexKey: static lyrics list won't be reordered
                             <Box key={i} sx={{ height: '0.7em' }} />
                           ) : (
                             <Typography
-                              key={i}
+                              key={
+                                // biome-ignore lint/suspicious/noArrayIndexKey: static lyrics list won't be reordered
+                                i
+                              }
                               level="body-sm"
                               sx={{ whiteSpace: 'pre-wrap', color: 'text.secondary' }}
                             >

--- a/app/radio/RadioPageClient.tsx
+++ b/app/radio/RadioPageClient.tsx
@@ -43,6 +43,41 @@ import {
 } from '@/lib/radio/state';
 import type { ExtractedPalette } from '@/lib/theme/artPalette';
 
+// ── Lyric section label helpers ──
+
+const SECTION_LABEL_RE = /^\[([^\]]+)\]$/;
+const SECTION_LABEL_FALLBACKS = ['#c4b5fd', '#a78bfa', '#818cf8'] as const;
+
+/**
+ * Converts text to Title Case, preserving digits and hyphenated segments.
+ * e.g. "pre-chorus" → "Pre-Chorus", "verse 1" → "Verse 1"
+ */
+function toTitleCase(text: string): string {
+  return text.toLowerCase().replace(/(?:^|\s|-)\S/g, (match) => match.toUpperCase());
+}
+
+/**
+ * Deterministic string hash mapping a label to an index 0-2.
+ */
+function hashLabelToIndex(label: string): number {
+  let hash = 0;
+  for (let i = 0; i < label.length; i++) {
+    hash = (hash << 5) - hash + label.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash) % 3;
+}
+
+function pickPaletteHex(index: number, palette: ExtractedPalette | null): string {
+  const idx = ((index % 3) + 3) % 3;
+  if (!palette) {
+    return SECTION_LABEL_FALLBACKS[idx] ?? SECTION_LABEL_FALLBACKS[0];
+  }
+  if (idx === 0) return palette.primary;
+  if (idx === 1) return palette.secondary;
+  return palette.tertiary;
+}
+
 const coverSlideIn = keyframes`
   from { transform: translateX(100%); opacity: 0; }
   to { transform: translateX(0); opacity: 1; }
@@ -1446,9 +1481,10 @@ export default function RadioPageClient() {
                     <Typography
                       level="body-sm"
                       sx={{
-                        color: 'text.tertiary',
+                        color: artPalette?.primary ?? 'primary.400',
                         textTransform: 'uppercase',
                         letterSpacing: '0.06em',
+                        transition: 'color 350ms ease',
                       }}
                     >
                       Lyrics
@@ -1503,12 +1539,44 @@ export default function RadioPageClient() {
                                 : 'none',
                         }}
                       >
-                        <Typography
-                          level="body-sm"
-                          sx={{ whiteSpace: 'pre-wrap', color: 'text.secondary' }}
-                        >
-                          {lyricsContent}
-                        </Typography>
+                        {(lyricsContent ?? '').split('\n').map((line, i) => {
+                          const sectionLabelMatch = line.match(SECTION_LABEL_RE);
+                          if (sectionLabelMatch?.[1]) {
+                            const labelText = toTitleCase(sectionLabelMatch[1]);
+                            const labelIdx = hashLabelToIndex(labelText);
+                            const labelColor = pickPaletteHex(labelIdx, artPalette);
+                            const glowColor = `${pickPaletteHex(labelIdx + 1, artPalette)}40`;
+                            return (
+                              <Typography
+                                key={i}
+                                level="body-sm"
+                                sx={{
+                                  color: labelColor,
+                                  textShadow: `0 0 6px ${glowColor}`,
+                                  transition: 'color 350ms ease',
+                                  fontWeight: 600,
+                                  textTransform: 'uppercase',
+                                  letterSpacing: '0.04em',
+                                  mt: i > 0 ? 1.5 : 0,
+                                  mb: 0.5,
+                                }}
+                              >
+                                {labelText}
+                              </Typography>
+                            );
+                          }
+                          return line === '' ? (
+                            <Box key={i} sx={{ height: '0.7em' }} />
+                          ) : (
+                            <Typography
+                              key={i}
+                              level="body-sm"
+                              sx={{ whiteSpace: 'pre-wrap', color: 'text.secondary' }}
+                            >
+                              {line}
+                            </Typography>
+                          );
+                        })}
                       </Box>
                     </Box>
                     {lyricsScrollBottom && (

--- a/app/radio/RadioPageClient.tsx
+++ b/app/radio/RadioPageClient.tsx
@@ -881,6 +881,9 @@ export default function RadioPageClient() {
   const title = currentTrack?.title ?? 'Finding current track…';
   const streamStateLabel = getStreamStateLabel(streamState);
 
+  const lyricsText = (probeData?.lyricsEng ?? '').trim();
+  const showLyrics = !!(probeData?.ok && lyricsText && !lyricsText.includes('[Instrumental]'));
+
   const volumeDots = React.useMemo(
     () =>
       Array.from({ length: 10 }, (_, i) => ({
@@ -1214,6 +1217,54 @@ export default function RadioPageClient() {
                 )}
               </Box>
             </Sheet>
+            {showLyrics ? (
+              <Sheet
+                variant="outlined"
+                sx={{
+                  display: { xs: 'none', md: 'flex' },
+                  flexDirection: 'column',
+                  mt: 1,
+                  maxHeight: '40%',
+                  overflow: 'auto',
+                  px: 2,
+                  py: 1.5,
+                  bgcolor: 'rgba(10,12,18,0.4)',
+                  borderColor: 'rgba(255,255,255,0.08)',
+                  borderRadius: 0,
+                }}
+              >
+                <Typography
+                  level="body-sm"
+                  sx={{
+                    color: 'text.tertiary',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                  }}
+                >
+                  Lyrics
+                </Typography>
+                <Box
+                  key={currentTrackId ?? 'idle'}
+                  sx={{ mt: 1, animation: `${fadeIn} 0.35s ease-out` }}
+                >
+                  {lyricsText ? (
+                    <Typography
+                      level="body-sm"
+                      sx={{ whiteSpace: 'pre-wrap', color: 'text.secondary' }}
+                    >
+                      {lyricsText}
+                    </Typography>
+                  ) : probeLoading ? (
+                    <Stack spacing={1}>
+                      <Skeleton variant="text" width="90%" />
+                      <Skeleton variant="text" width="75%" />
+                      <Skeleton variant="text" width="85%" />
+                      <Skeleton variant="text" width="60%" />
+                    </Stack>
+                  ) : null}
+                </Box>
+              </Sheet>
+            ) : null}
           </Stack>
         </Stack>
       </Box>

--- a/biome.json
+++ b/biome.json
@@ -34,6 +34,18 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["app/radio/RadioPageClient.tsx"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noArrayIndexKey": "off"
+          }
+        }
+      }
+    }
+  ],
   "javascript": {
     "formatter": {
       "quoteStyle": "single",

--- a/biome.json
+++ b/biome.json
@@ -34,18 +34,6 @@
       }
     }
   },
-  "overrides": [
-    {
-      "includes": ["app/radio/RadioPageClient.tsx"],
-      "linter": {
-        "rules": {
-          "suspicious": {
-            "noArrayIndexKey": "off"
-          }
-        }
-      }
-    }
-  ],
   "javascript": {
     "formatter": {
       "quoteStyle": "single",


### PR DESCRIPTION
## Summary
Adds a desktop-only animated lyrics panel to the radio page, rendering `lyricsEng` probe data with palette-derived section labels, lifecycle animations, scroll edge-fades, and reduced-motion support.

## Base
`midoriaiagents/aurora-20a31eea85` (lyricsEng probe extraction is already on that branch).

## Changes
- **app/radio/RadioPageClient.tsx** (+391 lines): Full lyrics panel feature including:
  - Section label parsing (`[Chorus]` etc.) with title-case rendering and deterministic palette color picking from the album art palette
  - Lifecycle state machine (hidden → entering → visible → exiting) with timer-coordinated animations
  - Keyframe animations: enter rise, exit drop, fade in/out, border glow
  - Scroll edge-fade gradient overlays (top and bottom) when content overflows
  - Desktop-only rendering (`xs:none, md:block`) below the Track Story sheet
  - `prefers-reduced-motion` detection for accessible animation fallback
  - Inline `biome-ignore` comments for `noArrayIndexKey` on static lyric line arrays (no separate biome.json override needed)

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
