### PR TITLE
Throttle radio current metadata polling and add per-process cache/coalescing

### DIFF
--- a/app/api/radio/current/route.ts
+++ b/app/api/radio/current/route.ts
@@ -69,6 +69,14 @@ export async function GET(request: NextRequest) {
     const rawChannel = request.nextUrl.searchParams.get('channel');
     const channel = normalizeChannel(rawChannel);
     const now = Date.now();
+
+    // Evict expired entries to prevent unbounded map growth from unused channels
+    for (const [ch, entry] of currentCache) {
+      if (!isValidCacheEntry(entry, now)) {
+        currentCache.delete(ch);
+      }
+    }
+
     const cached = currentCache.get(channel);
 
     if (isValidCacheEntry(cached, now)) {

--- a/app/api/radio/current/route.ts
+++ b/app/api/radio/current/route.ts
@@ -4,30 +4,98 @@ import { normalizeChannel } from '@/lib/radio/contract';
 export const runtime = 'nodejs';
 
 const RADIO_BASE_URL = 'https://radio.midori-ai.xyz';
+const CURRENT_CACHE_TTL_MS = 2_000;
+const UPSTREAM_TIMEOUT_MS = 3_000;
 
-export async function GET(request: NextRequest) {
+interface CurrentCacheEntry {
+  body: string;
+  contentType: string;
+  status: number;
+  createdAt: number;
+}
+
+const currentCache = new Map<string, CurrentCacheEntry>();
+const pendingCurrentRequests = new Map<string, Promise<CurrentCacheEntry>>();
+
+function isValidCacheEntry(
+  entry: CurrentCacheEntry | undefined,
+  now: number,
+): entry is CurrentCacheEntry {
+  return entry !== undefined && now - entry.createdAt < CURRENT_CACHE_TTL_MS;
+}
+
+function createCurrentResponse(entry: CurrentCacheEntry): NextResponse {
+  return new NextResponse(entry.body, {
+    status: entry.status,
+    headers: {
+      'Content-Type': entry.contentType,
+      'Cache-Control': 'no-store, no-cache, must-revalidate',
+    },
+  });
+}
+
+async function fetchCurrentFromUpstream(channel: string): Promise<CurrentCacheEntry> {
+  const upstreamUrl = `${RADIO_BASE_URL}/radio/v1/current?channel=${encodeURIComponent(channel)}`;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, UPSTREAM_TIMEOUT_MS);
+
   try {
-    const rawChannel = request.nextUrl.searchParams.get('channel');
-    const channel = normalizeChannel(rawChannel);
-    const upstreamUrl = `${RADIO_BASE_URL}/radio/v1/current?channel=${encodeURIComponent(channel)}`;
-
     const upstream = await fetch(upstreamUrl, {
       cache: 'no-store',
       headers: {
         Accept: 'application/json',
       },
+      signal: controller.signal,
     });
 
     const body = await upstream.text();
     const contentType = upstream.headers.get('content-type') ?? 'application/json';
 
-    return new NextResponse(body, {
+    return {
+      body,
+      contentType,
       status: upstream.status,
-      headers: {
-        'Content-Type': contentType,
-        'Cache-Control': 'no-store, no-cache, must-revalidate',
-      },
-    });
+      createdAt: Date.now(),
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const rawChannel = request.nextUrl.searchParams.get('channel');
+    const channel = normalizeChannel(rawChannel);
+    const now = Date.now();
+    const cached = currentCache.get(channel);
+
+    if (isValidCacheEntry(cached, now)) {
+      return createCurrentResponse(cached);
+    }
+
+    const pending = pendingCurrentRequests.get(channel);
+    if (pending !== undefined) {
+      return createCurrentResponse(await pending);
+    }
+
+    const upstreamRequest = fetchCurrentFromUpstream(channel);
+    pendingCurrentRequests.set(channel, upstreamRequest);
+
+    try {
+      const upstreamEntry = await upstreamRequest;
+
+      if (upstreamEntry.status >= 200 && upstreamEntry.status < 300) {
+        currentCache.set(channel, upstreamEntry);
+      }
+
+      return createCurrentResponse(upstreamEntry);
+    } finally {
+      if (pendingCurrentRequests.get(channel) === upstreamRequest) {
+        pendingCurrentRequests.delete(channel);
+      }
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown upstream error';
 

--- a/app/radio/RadioPageClient.tsx
+++ b/app/radio/RadioPageClient.tsx
@@ -145,7 +145,7 @@ interface ProgressSnapshot {
 }
 
 const DEFAULT_CHANNELS: ChannelEntry[] = [{ name: 'all', track_count: 0 }];
-const CURRENT_REFRESH_MS = 10_000;
+const CURRENT_REFRESH_MS = 2_000;
 const HEARTBEAT_MS = 30_000;
 const PROBE_DEBOUNCE_MS = 350;
 

--- a/components/radio/RadioWidget.test.tsx
+++ b/components/radio/RadioWidget.test.tsx
@@ -448,7 +448,7 @@ describe('RadioWidget', () => {
     const initialPlayCalls = lastAudio?.playCalls;
 
     currentTrackId = 'track-2';
-    await runInterval(10000);
+    await runInterval(2_000);
 
     await act(async () => {
       await flushEffects();

--- a/components/radio/RadioWidget.tsx
+++ b/components/radio/RadioWidget.tsx
@@ -591,7 +591,7 @@ export default function RadioWidget() {
 
     void refreshMetadata();
 
-    const intervalMs = playbackDesired ? 10_000 : 20_000;
+    const intervalMs = 2_000;
     const intervalId = window.setInterval(() => {
       void refreshMetadata();
     }, intervalMs);
@@ -599,7 +599,7 @@ export default function RadioWidget() {
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [refreshMetadata, playbackDesired, hydrated]);
+  }, [refreshMetadata, hydrated]);
 
   const prevChannelRef = React.useRef(channel);
 


### PR DESCRIPTION
### Motivation
- Reduce upstream load while updating current-song metadata on the page and widget within ~2 seconds and collapse duplicate requests from the same website-server process.
- Ensure stalled upstream metadata calls don't block future polls and allow timely retries.
- Preserve browser-side `Cache-Control: no-store` semantics while enabling a short-lived server-side optimization.

### Description
- Lowered the page polling constant from 10s to 2s in `app/radio/RadioPageClient.tsx` and set the floating widget metadata interval to 2s in `components/radio/RadioWidget.tsx`.
- Implemented a module-level per-channel in-memory cache in `app/api/radio/current/route.ts` with entries holding body, content type, status, and creation timestamp and a 2s TTL.
- Added per-channel in-flight request coalescing so concurrent requests await a single upstream fetch and made pending-request cleanup race-safe.
- Added a 3s upstream `AbortController` timeout and only cache successful (2xx) upstream responses while continuing to return the existing error JSON and `Cache-Control: no-store, no-cache, must-revalidate` headers.

### Testing
- Ran lint with `bun lint` and applied an automated fix via `bunx biome check --write` where applicable; lint completed with pre-existing Biome warnings/infos unrelated to these changes.
- Built the app with `bun run build`, which completed successfully (Turbopack emitted an existing NFT-list warning); build succeeded.
- Started the server and performed curl smoke checks against `/api/radio/current` to confirm `Cache-Control` headers and basic behavior, noting the live upstream returned 502 in this environment so live-success behavior was verified using mocks.
- Executed verification scripts with `NODE_PATH=/workspace/website-blog/node_modules bunx tsx /tmp/agents-artifacts/verify-radio-current-cache.ts` and `.../verify-radio-current-timeout.ts`, which confirmed cache hits within TTL, request coalescing, per-channel isolation, failures are not cached, timeout behavior, and successful retries; all verifications passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a511db87d688320bb88e209b5ebe60f)