### PR TITLE
Remove radio current completed-response cache

### DIFF
--- a/app/api/radio/current/route.test.ts
+++ b/app/api/radio/current/route.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { GET } from './route';
+
+const originalFetch = globalThis.fetch;
+
+function createRequest(channel: string) {
+  return {
+    nextUrl: new URL(`https://example.test/api/radio/current?channel=${channel}`),
+  } as Parameters<typeof GET>[0];
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('/api/radio/current', () => {
+  test('deduplicates concurrent requests for the same channel', async () => {
+    let resolveFetch: ((response: Response) => void) | undefined;
+    const upstreamFetches: string[] = [];
+
+    globalThis.fetch = ((url: string | URL | Request) => {
+      upstreamFetches.push(String(url));
+
+      return new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      });
+    }) as typeof fetch;
+
+    const firstResponsePromise = GET(createRequest('main'));
+    const secondResponsePromise = GET(createRequest('main'));
+
+    expect(upstreamFetches).toHaveLength(1);
+    expect(upstreamFetches[0]).toContain('channel=main');
+
+    resolveFetch?.(
+      new Response('{"track":"shared"}', {
+        headers: {
+          'content-type': 'application/json',
+        },
+        status: 200,
+      }),
+    );
+
+    const [firstResponse, secondResponse] = await Promise.all([
+      firstResponsePromise,
+      secondResponsePromise,
+    ]);
+
+    expect(await firstResponse.text()).toBe('{"track":"shared"}');
+    expect(await secondResponse.text()).toBe('{"track":"shared"}');
+    expect(firstResponse.headers.get('cache-control')).toBe('no-store, no-cache, must-revalidate');
+    expect(secondResponse.headers.get('cache-control')).toBe('no-store, no-cache, must-revalidate');
+  });
+
+  test('fetches fresh upstream metadata for later requests', async () => {
+    let upstreamFetchCount = 0;
+
+    globalThis.fetch = (() => {
+      upstreamFetchCount += 1;
+
+      return Promise.resolve(
+        new Response(`{"track":"fresh-${upstreamFetchCount}"}`, {
+          headers: {
+            'content-type': 'application/json',
+          },
+          status: 200,
+        }),
+      );
+    }) as typeof fetch;
+
+    const firstResponse = await GET(createRequest('main'));
+    const secondResponse = await GET(createRequest('main'));
+
+    expect(upstreamFetchCount).toBe(2);
+    expect(await firstResponse.text()).toBe('{"track":"fresh-1"}');
+    expect(await secondResponse.text()).toBe('{"track":"fresh-2"}');
+  });
+});

--- a/app/api/radio/current/route.ts
+++ b/app/api/radio/current/route.ts
@@ -4,25 +4,15 @@ import { normalizeChannel } from '@/lib/radio/contract';
 export const runtime = 'nodejs';
 
 const RADIO_BASE_URL = 'https://radio.midori-ai.xyz';
-const CURRENT_CACHE_TTL_MS = 2_000;
 const UPSTREAM_TIMEOUT_MS = 3_000;
 
 interface CurrentCacheEntry {
   body: string;
   contentType: string;
   status: number;
-  createdAt: number;
 }
 
-const currentCache = new Map<string, CurrentCacheEntry>();
 const pendingCurrentRequests = new Map<string, Promise<CurrentCacheEntry>>();
-
-function isValidCacheEntry(
-  entry: CurrentCacheEntry | undefined,
-  now: number,
-): entry is CurrentCacheEntry {
-  return entry !== undefined && now - entry.createdAt < CURRENT_CACHE_TTL_MS;
-}
 
 function createCurrentResponse(entry: CurrentCacheEntry): NextResponse {
   return new NextResponse(entry.body, {
@@ -57,7 +47,6 @@ async function fetchCurrentFromUpstream(channel: string): Promise<CurrentCacheEn
       body,
       contentType,
       status: upstream.status,
-      createdAt: Date.now(),
     };
   } finally {
     clearTimeout(timeoutId);
@@ -68,21 +57,6 @@ export async function GET(request: NextRequest) {
   try {
     const rawChannel = request.nextUrl.searchParams.get('channel');
     const channel = normalizeChannel(rawChannel);
-    const now = Date.now();
-
-    // Evict expired entries to prevent unbounded map growth from unused channels
-    for (const [ch, entry] of currentCache) {
-      if (!isValidCacheEntry(entry, now)) {
-        currentCache.delete(ch);
-      }
-    }
-
-    const cached = currentCache.get(channel);
-
-    if (isValidCacheEntry(cached, now)) {
-      return createCurrentResponse(cached);
-    }
-
     const pending = pendingCurrentRequests.get(channel);
     if (pending !== undefined) {
       return createCurrentResponse(await pending);
@@ -92,13 +66,7 @@ export async function GET(request: NextRequest) {
     pendingCurrentRequests.set(channel, upstreamRequest);
 
     try {
-      const upstreamEntry = await upstreamRequest;
-
-      if (upstreamEntry.status >= 200 && upstreamEntry.status < 300) {
-        currentCache.set(channel, upstreamEntry);
-      }
-
-      return createCurrentResponse(upstreamEntry);
+      return createCurrentResponse(await upstreamRequest);
     } finally {
       if (pendingCurrentRequests.get(channel) === upstreamRequest) {
         pendingCurrentRequests.delete(channel);


### PR DESCRIPTION
### Motivation
- Ensure `/api/radio/current` always returns fresh upstream metadata for subsequent requests while still avoiding duplicate upstream fetches for concurrent requests.
- Simplify cache machinery by removing the short-lived completed-response cache and its TTL/eviction logic which caused stale responses to be served.
- Preserve the existing behavior that in-flight requests are deduplicated so multiple simultaneous callers share one upstream fetch.

### Description
- Removed the completed-response cache and TTL handling by deleting `CURRENT_CACHE_TTL_MS`, `currentCache`, `CurrentCacheEntry.createdAt`, and `isValidCacheEntry` from `app/api/radio/current/route.ts`.
- Kept `pendingCurrentRequests` so concurrent requests for the same normalized channel share a single `fetchCurrentFromUpstream` promise.
- In `GET`, skipped cache lookup and eviction loops so the route immediately checks `pendingCurrentRequests` and otherwise forwards the upstream response directly without storing it.
- Continued to return responses with `Cache-Control: no-store, no-cache, must-revalidate` and preserved upstream timeout and error handling.
- Added `app/api/radio/current/route.test.ts` with tests that assert concurrent deduplication and that sequential requests fetch fresh upstream metadata.

### Testing
- Ran `bunx biome check --write app/api/radio/current/route.ts app/api/radio/current/route.test.ts` to fix formatting issues in the modified files and validate lintable errors, which succeeded.
- Ran `bun test app/api/radio/current/route.test.ts` and the new test file passed both tests validating deduplication and fresh sequential fetches.
- Ran the full test suite with `bun test` and observed the suite completed successfully (all tests passed in this run).
- Ran `bun lint` (Biome reported non-blocking configuration/deprecation infos and a couple of optional-chain suggestions but no failing lint errors blocking the PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52698066ac8320be250fffd1a16582)