### PR TITLE
Overhaul prose-first TTS with resilient timing and range delivery

### DIFF
--- a/app/api/tts/audio/[type]/[slug]/route.test.ts
+++ b/app/api/tts/audio/[type]/[slug]/route.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { GET } from './route';
+
+const originalFetch = globalThis.fetch;
+const contentHash = 'a'.repeat(64);
+const params = { params: Promise.resolve({ type: 'blog', slug: 'shared-post' }) };
+
+function createRequest(range: string) {
+  return {
+    headers: new Headers({ range }),
+    nextUrl: new URL(
+      `https://example.test/api/tts/audio/blog/shared-post?content_hash=${contentHash}&cache_version=3`,
+    ),
+  } as Parameters<typeof GET>[0];
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('/api/tts/audio/[type]/[slug]', () => {
+  test('preserves successful partial-content responses and forwards Range', async () => {
+    let receivedRange = '';
+
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      receivedRange = new Headers(init?.headers).get('range') ?? '';
+      return new Response('audio bytes', {
+        headers: {
+          'accept-ranges': 'bytes',
+          'content-range': 'bytes 0-10/100',
+          'content-type': 'audio/wav',
+        },
+        status: 206,
+      });
+    }) as unknown as typeof fetch;
+
+    const response = await GET(createRequest('bytes=0-10'), params);
+
+    expect(response.status).toBe(206);
+    expect(receivedRange).toBe('bytes=0-10');
+    expect(response.headers.get('accept-ranges')).toBe('bytes');
+    expect(response.headers.get('content-range')).toBe('bytes 0-10/100');
+    expect(await response.text()).toBe('audio bytes');
+  });
+
+  test('preserves upstream Range metadata for an invalid 416 response', async () => {
+    globalThis.fetch = (async () =>
+      new Response('invalid range', {
+        headers: {
+          'accept-ranges': 'bytes',
+          'content-range': 'bytes */100',
+          'content-type': 'audio/wav',
+        },
+        status: 416,
+      })) as unknown as typeof fetch;
+
+    const response = await GET(createRequest('bytes=100-'), params);
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get('accept-ranges')).toBe('bytes');
+    expect(response.headers.get('content-range')).toBe('bytes */100');
+    expect(await response.text()).toBe('invalid range');
+  });
+});

--- a/app/api/tts/audio/[type]/[slug]/route.test.ts
+++ b/app/api/tts/audio/[type]/[slug]/route.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
+import { TTS_CACHE_VERSION } from '@/lib/tts/contract';
 import { GET } from './route';
 
 const originalFetch = globalThis.fetch;
@@ -9,7 +10,7 @@ function createRequest(range: string) {
   return {
     headers: new Headers({ range }),
     nextUrl: new URL(
-      `https://example.test/api/tts/audio/blog/shared-post?content_hash=${contentHash}&cache_version=3`,
+      `https://example.test/api/tts/audio/blog/shared-post?content_hash=${contentHash}&cache_version=${TTS_CACHE_VERSION}`,
     ),
   } as Parameters<typeof GET>[0];
 }

--- a/app/api/tts/audio/[type]/[slug]/route.ts
+++ b/app/api/tts/audio/[type]/[slug]/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { isValidTtsIdentity, ttsIdentityQuery } from '@/lib/tts/contract';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -11,9 +12,18 @@ export async function GET(
 ) {
   try {
     const { type, slug } = await params;
+    const contentHash = request.nextUrl.searchParams.get('content_hash');
+    const cacheVersion = request.nextUrl.searchParams.get('cache_version');
 
     if (!['blog', 'lore'].includes(type)) {
       return NextResponse.json({ error: 'Invalid type' }, { status: 400 });
+    }
+
+    if (!isValidTtsIdentity(contentHash, cacheVersion)) {
+      return NextResponse.json(
+        { error: 'Invalid TTS content hash or cache version' },
+        { status: 400 },
+      );
     }
 
     const upstreamHeaders = new Headers();
@@ -23,7 +33,7 @@ export async function GET(
     }
 
     const upstream = await fetch(
-      `${TTS_BASE}/audio/${encodeURIComponent(type)}/${encodeURIComponent(slug)}`,
+      `${TTS_BASE}/audio/${encodeURIComponent(type)}/${encodeURIComponent(slug)}?${ttsIdentityQuery(contentHash ?? '')}`,
       {
         cache: 'no-store',
         headers: upstreamHeaders,
@@ -40,7 +50,10 @@ export async function GET(
 
     const responseHeaders = new Headers(upstream.headers);
     responseHeaders.set('Cache-Control', 'public, max-age=86400');
-    responseHeaders.set('Content-Disposition', `inline; filename="${slug}.wav"`);
+    responseHeaders.set(
+      'Content-Disposition',
+      `inline; filename="${slug}-${contentHash?.slice(0, 12)}.wav"`,
+    );
 
     return new NextResponse(upstream.body, {
       status: upstream.status,

--- a/app/api/tts/audio/[type]/[slug]/route.ts
+++ b/app/api/tts/audio/[type]/[slug]/route.ts
@@ -44,6 +44,13 @@ export async function GET(
       return NextResponse.json({ error: 'Audio not found' }, { status: 404 });
     }
 
+    if (upstream.status === 416) {
+      return new NextResponse(upstream.body, {
+        status: upstream.status,
+        headers: new Headers(upstream.headers),
+      });
+    }
+
     if (!upstream.ok) {
       return NextResponse.json({ error: 'Upstream error' }, { status: upstream.status });
     }

--- a/app/api/tts/chunk/[type]/[slug]/[index]/route.ts
+++ b/app/api/tts/chunk/[type]/[slug]/[index]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { isValidTtsIdentity, ttsIdentityQuery } from '@/lib/tts/contract';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -6,14 +7,24 @@ export const dynamic = 'force-dynamic';
 const TTS_BASE = 'http://127.0.0.1:8888';
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ type: string; slug: string; index: string }> },
 ) {
   try {
     const { type, slug, index } = await params;
+    const requestUrl = new URL(request.url);
+    const contentHash = requestUrl.searchParams.get('content_hash');
+    const cacheVersion = requestUrl.searchParams.get('cache_version');
 
     if (!['blog', 'lore'].includes(type)) {
       return NextResponse.json({ error: 'Invalid type' }, { status: 400 });
+    }
+
+    if (!isValidTtsIdentity(contentHash, cacheVersion)) {
+      return NextResponse.json(
+        { error: 'Invalid TTS content hash or cache version' },
+        { status: 400 },
+      );
     }
 
     const parsedIndex = Number(index);
@@ -25,7 +36,7 @@ export async function GET(
     }
 
     const upstream = await fetch(
-      `${TTS_BASE}/chunk/${encodeURIComponent(type)}/${encodeURIComponent(slug)}/${parsedIndex}`,
+      `${TTS_BASE}/chunk/${encodeURIComponent(type)}/${encodeURIComponent(slug)}/${parsedIndex}?${ttsIdentityQuery(contentHash ?? '')}`,
       { cache: 'no-store' },
     );
 
@@ -42,7 +53,7 @@ export async function GET(
     responseHeaders.set('Cache-Control', 'no-store');
     responseHeaders.set(
       'Content-Disposition',
-      `inline; filename="${slug}-${String(parsedIndex).padStart(4, '0')}.wav"`,
+      `inline; filename="${slug}-${contentHash?.slice(0, 12)}-${String(parsedIndex).padStart(4, '0')}.wav"`,
     );
 
     return new NextResponse(upstream.body, {

--- a/app/api/tts/generate/route.ts
+++ b/app/api/tts/generate/route.ts
@@ -1,4 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { isValidTtsIdentity } from '@/lib/tts/contract';
+import type { SpeechDocument } from '@/lib/tts/speechDocument';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -8,15 +10,17 @@ const TTS_BASE = 'http://127.0.0.1:8888';
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { text, slug, type } = body as {
-      text: string;
+    const { document, slug, type, content_hash, cache_version } = body as {
+      document: SpeechDocument;
       slug: string;
       type: string;
+      content_hash: string;
+      cache_version: string;
     };
 
-    if (!text || !slug || !type) {
+    if (!document?.text || !document.paragraphs?.length || !slug || !type) {
       return NextResponse.json(
-        { error: 'Missing required fields: text, slug, type' },
+        { error: 'Missing required fields: document, slug, type' },
         { status: 400 },
       );
     }
@@ -28,10 +32,26 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (!isValidTtsIdentity(content_hash, cache_version)) {
+      return NextResponse.json(
+        { error: 'Invalid TTS content hash or cache version' },
+        { status: 400 },
+      );
+    }
+    if (
+      request.nextUrl.searchParams.get('content_hash') !== content_hash ||
+      request.nextUrl.searchParams.get('cache_version') !== cache_version
+    ) {
+      return NextResponse.json(
+        { error: 'TTS request URL identity does not match its body' },
+        { status: 409 },
+      );
+    }
+
     const upstream = await fetch(`${TTS_BASE}/generate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text, slug, type }),
+      body: JSON.stringify({ document, slug, type, content_hash, cache_version }),
       cache: 'no-store',
     });
 

--- a/app/api/tts/status/route.ts
+++ b/app/api/tts/status/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { isValidTtsIdentity } from '@/lib/tts/contract';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -9,6 +10,8 @@ export async function GET(request: NextRequest) {
   try {
     const slug = request.nextUrl.searchParams.get('slug');
     const type = request.nextUrl.searchParams.get('type');
+    const contentHash = request.nextUrl.searchParams.get('content_hash');
+    const cacheVersion = request.nextUrl.searchParams.get('cache_version');
 
     if (!slug || !type) {
       return NextResponse.json(
@@ -17,8 +20,15 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    if (!isValidTtsIdentity(contentHash, cacheVersion)) {
+      return NextResponse.json(
+        { error: 'Invalid TTS content hash or cache version' },
+        { status: 400 },
+      );
+    }
+
     const upstream = await fetch(
-      `${TTS_BASE}/status?slug=${encodeURIComponent(slug)}&type=${encodeURIComponent(type)}`,
+      `${TTS_BASE}/status?slug=${encodeURIComponent(slug)}&type=${encodeURIComponent(type)}&content_hash=${encodeURIComponent(contentHash ?? '')}&cache_version=${encodeURIComponent(cacheVersion ?? '')}`,
       { cache: 'no-store' },
     );
 
@@ -40,6 +50,8 @@ export async function GET(request: NextRequest) {
         generated_chunks: 0,
         total_chunks: 0,
         playable: false,
+        cache_version: request.nextUrl.searchParams.get('cache_version') ?? '',
+        content_hash: request.nextUrl.searchParams.get('content_hash') ?? '',
         error: 'TTS service unavailable',
         detail: message,
       },

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/joy": "^5.0.0-beta.52",
+        "@types/mdast": "^4.0.4",
         "@types/qrcode": "^1.5.6",
         "gray-matter": "4.0.3",
         "highlight.js": "^11.11.1",
@@ -20,7 +21,9 @@
         "rehype-highlight": "^7.0.2",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
         "sharp": "^0.35.2",
+        "unified": "^11.0.5",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/components/blog/PostView.test.tsx
+++ b/components/blog/PostView.test.tsx
@@ -94,6 +94,15 @@ describe('PostView', () => {
     expect(html).toContain('Go to next story');
   });
 
+  test('does not mount TTS requests before password-gated lore is unlocked', () => {
+    const html = renderToStaticMarkup(
+      <PostView post={mockPost} onClose={() => {}} postType="lore" ttsLocked />,
+    );
+
+    expect(html).toContain('Audio unlocks with this post');
+    expect(html).not.toContain('Generate audio for this post');
+  });
+
   test('styles balanced dialogue in prose', () => {
     const html = renderPostContent('She said "Hello there." and waved.');
 

--- a/components/blog/PostView.test.tsx
+++ b/components/blog/PostView.test.tsx
@@ -155,6 +155,20 @@ describe('PostView', () => {
     expect(html).toContain('<code>a—b</code>');
   });
 
+  test('ships readable inline TTS and Layer One highlight styles', () => {
+    const html = renderPostContent('Normal prose.\n\n```layerone\nsignal\n```');
+
+    expect(html).toContain('.tts-highlight--statement');
+    expect(html).toContain('tts-watercolor 8s ease-in-out infinite alternate');
+    expect(html).toContain('currentColor 75%');
+    expect(html).toContain('pre.tts-layerone-active');
+    expect(html).toContain('tts-layerone-switch-block 600ms');
+    expect(html).toContain('--tts-layerone-red-alpha 10s');
+    expect(html).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(html).not.toContain('::highlight(');
+    expect(html).not.toContain('CSS.highlights');
+  });
+
   test('renders inline thinking tags as styled content without showing tags', () => {
     const html = renderPostContent('Before <thinking>fuck</thinking> after.');
 

--- a/components/blog/PostView.tsx
+++ b/components/blog/PostView.tsx
@@ -53,6 +53,7 @@ import {
   extractPaletteFromImage,
 } from '@/lib/theme/artPalette';
 import type { TtsHighlightRange } from '@/lib/tts/contract';
+import { applyTtsHighlight, clearTtsHighlights } from '@/lib/tts/highlight';
 import { deriveSpeechDocument, type SpeechDocument } from '@/lib/tts/speechDocument';
 import type { ParsedPost } from '../../lib/blog/parser';
 import { TtsPlayer } from './TtsPlayer';
@@ -290,143 +291,6 @@ function buildTooltipText(
   return `${prefix}: ${story.title} - ${snippet}`;
 }
 
-interface NormalizedDomText {
-  text: string;
-  starts: Array<{ node: Text; offset: number }>;
-  ends: Array<{ node: Text; offset: number }>;
-}
-
-function normalizeSpeechDomText(
-  root: Element,
-  excludedDescendants: Set<Element>,
-): NormalizedDomText {
-  const textNodes: Text[] = [];
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-  let current = walker.nextNode();
-  while (current) {
-    const textNode = current as Text;
-    const parent = textNode.parentElement;
-    if (
-      parent &&
-      !Array.from(excludedDescendants).some(
-        (excluded) => excluded === parent || excluded.contains(parent),
-      )
-    ) {
-      textNodes.push(textNode);
-    }
-    current = walker.nextNode();
-  }
-
-  let text = '';
-  const starts: NormalizedDomText['starts'] = [];
-  const ends: NormalizedDomText['ends'] = [];
-  let pendingWhitespaceStart: { node: Text; offset: number } | null = null;
-  let pendingWhitespaceEnd: { node: Text; offset: number } | null = null;
-
-  for (const node of textNodes) {
-    for (let offset = 0; offset < node.data.length; offset += 1) {
-      const character = node.data[offset] ?? '';
-      if (/\s/u.test(character)) {
-        pendingWhitespaceStart ??= { node, offset };
-        pendingWhitespaceEnd = { node, offset: offset + 1 };
-        continue;
-      }
-
-      if (pendingWhitespaceStart && pendingWhitespaceEnd && text.length > 0) {
-        text += ' ';
-        starts.push(pendingWhitespaceStart);
-        ends.push(pendingWhitespaceEnd);
-      }
-      pendingWhitespaceStart = null;
-      pendingWhitespaceEnd = null;
-      text += character;
-      starts.push({ node, offset });
-      ends.push({ node, offset: offset + 1 });
-    }
-  }
-
-  return { text, starts, ends };
-}
-
-function getSpeechDomCandidates(root: HTMLElement): NormalizedDomText[] {
-  const candidates: NormalizedDomText[] = [];
-  for (const element of root.querySelectorAll('p, li, pre')) {
-    if (element.closest('h1, h2, h3, h4, h5, h6, table')) continue;
-
-    if (element.tagName === 'PRE') {
-      const layerone = element.querySelector('code.language-layerone');
-      if (!layerone) continue;
-      candidates.push(normalizeSpeechDomText(layerone, new Set()));
-      continue;
-    }
-
-    if (
-      element.tagName === 'LI' &&
-      Array.from(element.children).some((child) => child.tagName === 'P')
-    ) {
-      continue;
-    }
-
-    const excluded = new Set<Element>();
-    for (const descendant of element.querySelectorAll('code, pre, img, table, ul, ol')) {
-      if (
-        element.tagName === 'LI' &&
-        (descendant.tagName === 'UL' || descendant.tagName === 'OL')
-      ) {
-        excluded.add(descendant);
-      } else if (descendant.tagName === 'CODE' || descendant.tagName === 'PRE') {
-        excluded.add(descendant);
-      }
-    }
-    candidates.push(normalizeSpeechDomText(element, excluded));
-  }
-  return candidates.filter((candidate) => candidate.text.length > 0);
-}
-
-function createSpeechHighlightRanges(
-  root: HTMLElement,
-  speechDocument: SpeechDocument,
-  activeRange: TtsHighlightRange,
-): Range[] {
-  const candidates = getSpeechDomCandidates(root);
-  const paragraphMappings: Array<NormalizedDomText | null> = [];
-  let candidateIndex = 0;
-
-  for (const paragraph of speechDocument.paragraphs) {
-    const expected = speechDocument.text.slice(paragraph.start, paragraph.end);
-    let mapping: NormalizedDomText | null = null;
-    while (candidateIndex < candidates.length) {
-      const candidate = candidates[candidateIndex] ?? null;
-      candidateIndex += 1;
-      if (candidate?.text === expected) {
-        mapping = candidate;
-        break;
-      }
-    }
-    paragraphMappings.push(mapping);
-  }
-
-  const ranges: Range[] = [];
-  speechDocument.paragraphs.forEach((paragraph, index) => {
-    const start = Math.max(activeRange.start, paragraph.start);
-    const end = Math.min(activeRange.end, paragraph.end);
-    const mapping = paragraphMappings[index];
-    if (!mapping || end <= start) return;
-
-    const relativeStart = start - paragraph.start;
-    const relativeEnd = end - paragraph.start;
-    const rangeStart = mapping.starts[relativeStart];
-    const rangeEnd = mapping.ends[relativeEnd - 1];
-    if (!rangeStart || !rangeEnd) return;
-
-    const range = document.createRange();
-    range.setStart(rangeStart.node, rangeStart.offset);
-    range.setEnd(rangeEnd.node, rangeEnd.offset);
-    ranges.push(range);
-  });
-  return ranges;
-}
-
 interface PostContentSectionProps {
   post: ParsedPost;
   isScheduledPreview: boolean;
@@ -457,12 +321,12 @@ function PostContentSection({
   ttsHighlightRange,
 }: PostContentSectionProps) {
   const contentRef = useRef<HTMLDivElement>(null);
-  const highlightNameBase = useMemo(
-    () => `tts-${post.filename.replace(/[^a-z0-9-]/gi, '-').toLowerCase()}`,
-    [post.filename],
-  );
-  const statementHighlightName = `${highlightNameBase}-statement`;
-  const chunkHighlightName = `${highlightNameBase}-chunk`;
+  // Wire this up to the button when Luna is ready.
+  const [ttsAutoFollowEnabled] = useState(true);
+  const followSuppressedRef = useRef(false);
+  const programmaticScrollRef = useRef(false);
+  const programmaticScrollTimerRef = useRef<number | null>(null);
+  const previousSpeechDocumentRef = useRef(speechDocument);
 
   const markdownContent = useMemo(() => {
     return preparePostMarkdown(post.content);
@@ -757,35 +621,92 @@ function PostContentSection({
     };
   }, []);
 
+  useEffect(() => {
+    if (!ttsHighlightRange) return;
+
+    const shouldSuppress = () => {
+      if (programmaticScrollRef.current) return;
+      followSuppressedRef.current = true;
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (
+        target?.matches('input, textarea, select, [contenteditable="true"]') ||
+        !['ArrowDown', 'ArrowUp', 'End', 'Home', 'PageDown', 'PageUp', ' '].includes(event.key)
+      ) {
+        return;
+      }
+      shouldSuppress();
+    };
+
+    window.addEventListener('wheel', shouldSuppress, { passive: true });
+    window.addEventListener('touchmove', shouldSuppress, { passive: true });
+    window.addEventListener('scroll', shouldSuppress, { passive: true });
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('wheel', shouldSuppress);
+      window.removeEventListener('touchmove', shouldSuppress);
+      window.removeEventListener('scroll', shouldSuppress);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [ttsHighlightRange]);
+
   useLayoutEffect(() => {
     const root = contentRef.current;
-    if (typeof CSS === 'undefined') return;
-    const registry = (
-      CSS as unknown as {
-        highlights?: {
-          delete: (name: string) => void;
-          set: (name: string, value: unknown) => void;
-        };
-      }
-    ).highlights;
-    const HighlightConstructor = (
-      window as unknown as { Highlight?: new (...ranges: Range[]) => unknown }
-    ).Highlight;
-    const names = [statementHighlightName, chunkHighlightName];
-    names.forEach((name) => {
-      registry?.delete(name);
-    });
+    if (!root) return;
 
-    if (!root || !registry || !HighlightConstructor || !ttsHighlightRange) return;
-    const ranges = createSpeechHighlightRanges(root, speechDocument, ttsHighlightRange);
-    if (ranges.length === 0) return;
-    const name =
-      ttsHighlightRange.precision === 'statement' ? statementHighlightName : chunkHighlightName;
-    registry.set(name, new HighlightConstructor(...ranges));
+    if (previousSpeechDocumentRef.current !== speechDocument) {
+      clearTtsHighlights(root);
+      previousSpeechDocumentRef.current = speechDocument;
+    }
+
+    if (!ttsHighlightRange) {
+      clearTtsHighlights(root, { normal: 'transition', layerone: 'linger' });
+      return;
+    }
+
+    applyTtsHighlight(root, speechDocument, ttsHighlightRange);
+    if (!ttsAutoFollowEnabled || followSuppressedRef.current) return;
+
+    const targets = Array.from(
+      root.querySelectorAll<HTMLElement>(
+        'pre.tts-layerone-active, .tts-highlight--entering, .tts-highlight--active',
+      ),
+    );
+    if (targets.length === 0) return;
+
+    const first = targets[0];
+    const last = targets.at(-1);
+    if (!first || !last) return;
+    const firstRect = first.getBoundingClientRect();
+    const lastRect = last.getBoundingClientRect();
+    const target = firstRect.top < 0 ? first : lastRect.bottom > window.innerHeight ? last : null;
+    if (!target) return;
+
+    programmaticScrollRef.current = true;
+    if (programmaticScrollTimerRef.current !== null) {
+      window.clearTimeout(programmaticScrollTimerRef.current);
+    }
+    target.scrollIntoView({
+      behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
+    });
+    programmaticScrollTimerRef.current = window.setTimeout(() => {
+      programmaticScrollRef.current = false;
+      programmaticScrollTimerRef.current = null;
+    }, 1000);
+  }, [speechDocument, ttsAutoFollowEnabled, ttsHighlightRange]);
+
+  useLayoutEffect(() => {
     return () => {
-      registry.delete(name);
+      if (programmaticScrollTimerRef.current !== null) {
+        window.clearTimeout(programmaticScrollTimerRef.current);
+      }
+      const root = contentRef.current;
+      if (root) clearTtsHighlights(root);
     };
-  }, [chunkHighlightName, speechDocument, statementHighlightName, ttsHighlightRange]);
+  }, []);
 
   return (
     <>
@@ -805,13 +726,159 @@ function PostContentSection({
             font-style: normal;
             font-display: swap;
           }
-          ::highlight(${statementHighlightName}) {
-            background-color: rgba(250, 204, 21, 0.3);
+          @property --tts-layerone-red-alpha {
+            syntax: '<number>';
+            inherits: false;
+            initial-value: 0;
+          }
+          @keyframes tts-watercolor {
+            0% { background-position: 0% 50%; }
+            100% { background-position: 100% 50%; }
+          }
+          @keyframes tts-highlight-wipe-in {
+            0% { background-size: 0% 100%; color: inherit; }
+            100% { background-size: 200% 100%; color: var(--tts-highlight-color); }
+          }
+          @keyframes tts-highlight-wipe-out {
+            0% { background-size: 200% 100%; color: var(--tts-highlight-color); }
+            100% { background-size: 0% 100%; color: inherit; }
+          }
+          @keyframes tts-layerone-switch-block {
+            0% {
+              --tts-layerone-red-alpha: 0;
+              border-color: rgba(0, 255, 200, 0.25);
+              box-shadow: none;
+            }
+            20% {
+              --tts-layerone-red-alpha: 0.4;
+              border-color: rgba(239, 68, 68, 0.95);
+              box-shadow: 0 0 10px rgba(239, 68, 68, 0.28);
+            }
+            38% {
+              --tts-layerone-red-alpha: 0.12;
+              border-color: rgba(0, 255, 200, 0.35);
+              box-shadow: 0 0 3px rgba(239, 68, 68, 0.12);
+            }
+            58%, 100% {
+              --tts-layerone-red-alpha: 0.4;
+              border-color: rgba(239, 68, 68, 0.95);
+              box-shadow: 0 0 10px rgba(239, 68, 68, 0.28);
+            }
+          }
+          @keyframes tts-layerone-switch-text {
+            0% { color: #7fffe0; transform: translateX(0); }
+            20% { color: #e2e8f0; transform: translateX(1px); }
+            38% { color: #7fffe0; transform: translateX(-1px); }
+            58%, 100% { color: #e2e8f0; transform: translateX(0); }
+          }
+          .tts-highlight {
+            --tts-highlight-color: color-mix(in srgb, currentColor 75%, #e2e8f0 25%);
+            background-repeat: no-repeat;
+            background-position: left center;
+            background-size: 200% 100%;
+            border-radius: 3px;
+            padding: 1px 0;
+            box-decoration-break: clone;
+            -webkit-box-decoration-break: clone;
             color: inherit;
           }
-          ::highlight(${chunkHighlightName}) {
-            background-color: rgba(125, 211, 252, 0.16);
-            color: inherit;
+          .tts-highlight--statement {
+            background-image: linear-gradient(
+              120deg,
+              rgba(139, 92, 246, 0.14),
+              rgba(167, 139, 250, 0.28),
+              rgba(139, 92, 246, 0.14)
+            );
+          }
+          .tts-highlight--chunk {
+            --tts-highlight-color: color-mix(in srgb, currentColor 90%, #e2e8f0 10%);
+            background-image: linear-gradient(
+              120deg,
+              rgba(139, 92, 246, 0.10),
+              rgba(167, 139, 250, 0.20),
+              rgba(139, 92, 246, 0.10)
+            );
+          }
+          [data-dialogue='true'] .tts-highlight--statement {
+            --tts-highlight-color: color-mix(in srgb, currentColor 70%, #e2e8f0 30%);
+          }
+          [data-dialogue='true'] .tts-highlight--chunk {
+            --tts-highlight-color: color-mix(in srgb, currentColor 80%, #e2e8f0 20%);
+          }
+          [data-thinking] .tts-highlight {
+            -webkit-text-fill-color: currentColor;
+          }
+          .tts-highlight--entering {
+            animation: tts-highlight-wipe-in var(--tts-handoff-ms) ease-in forwards;
+          }
+          .tts-highlight--active {
+            color: var(--tts-highlight-color);
+            animation: tts-watercolor 8s ease-in-out infinite alternate;
+          }
+          .tts-highlight--exiting {
+            background-position: right center;
+            animation: tts-highlight-wipe-out var(--tts-handoff-ms) ease-in forwards;
+          }
+          pre.tts-layerone-active,
+          pre.tts-layerone-lingering {
+            background-image: linear-gradient(
+              rgba(239, 68, 68, var(--tts-layerone-red-alpha)),
+              rgba(239, 68, 68, var(--tts-layerone-red-alpha))
+            ) !important;
+          }
+          pre.tts-layerone-active {
+            --tts-layerone-red-alpha: 0.4;
+            border-color: rgba(239, 68, 68, 0.95) !important;
+            box-shadow: 0 0 10px rgba(239, 68, 68, 0.28);
+          }
+          pre.tts-layerone-active code.language-layerone {
+            color: #e2e8f0 !important;
+            -webkit-text-fill-color: #e2e8f0 !important;
+          }
+          pre.tts-layerone-entering {
+            animation: tts-layerone-switch-block 600ms steps(1, end) forwards;
+          }
+          pre.tts-layerone-entering code.language-layerone {
+            animation: tts-layerone-switch-text 600ms steps(1, end) forwards !important;
+          }
+          pre.tts-layerone-lingering {
+            --tts-layerone-red-alpha: 0;
+            border-color: rgba(0, 255, 200, 0.25) !important;
+            box-shadow: none;
+            transition:
+              --tts-layerone-red-alpha 10s cubic-bezier(0.16, 1, 0.3, 1),
+              border-color 10s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 10s cubic-bezier(0.16, 1, 0.3, 1);
+          }
+          pre.tts-layerone-lingering code.language-layerone {
+            color: #7fffe0 !important;
+            -webkit-text-fill-color: #7fffe0 !important;
+            transition:
+              color 10s cubic-bezier(0.16, 1, 0.3, 1),
+              -webkit-text-fill-color 10s cubic-bezier(0.16, 1, 0.3, 1);
+          }
+          @media (prefers-reduced-motion: reduce) {
+            .tts-highlight--entering,
+            .tts-highlight--active,
+            .tts-highlight--exiting {
+              animation: none !important;
+              background-size: 200% 100%;
+              color: var(--tts-highlight-color);
+            }
+            pre.tts-layerone-entering,
+            pre.tts-layerone-entering code.language-layerone {
+              animation: none !important;
+            }
+            pre.tts-layerone-lingering,
+            pre.tts-layerone-lingering code.language-layerone {
+              transition: none !important;
+            }
+          }
+          @supports not (color: color-mix(in srgb, white, black)) {
+            .tts-highlight {
+              --tts-highlight-color: inherit;
+              color: inherit;
+            }
           }
         `}
       />

--- a/components/blog/PostView.tsx
+++ b/components/blog/PostView.tsx
@@ -17,7 +17,15 @@
 import { Global, keyframes } from '@emotion/react';
 import { Box, Button, Card, Chip, Divider, IconButton, Stack, Tooltip, Typography } from '@mui/joy';
 import { ArrowLeft, Calendar, ChevronLeft, ChevronRight, Lock, Tag, User } from 'lucide-react';
-import { type ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { Components } from 'react-markdown';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
@@ -27,16 +35,13 @@ import { AMBIENT_PULSE_KEYFRAMES, AmbientCoverArt } from '@/components/blog/Ambi
 import { useDynamicBackdrop } from '@/components/DynamicBackdropProvider';
 import { SpeciesCareCardEmbed } from '@/components/species-care/SpeciesCareCardEmbed';
 import { shouldInsertSpaceBetweenTitleSegments } from '@/lib/blog/titleSegments';
-import {
-  POST_COVER_PLACEHOLDER_IMAGE_URL,
-  resolvePostCoverImageUrl,
-  toLoreImageApiUrl,
-} from '@/lib/content/imageUrl';
+import { POST_COVER_PLACEHOLDER_IMAGE_URL, resolvePostCoverImageUrl } from '@/lib/content/imageUrl';
 import {
   extractIsoDateFromBlogFilename,
   formatLongDate,
   normalizeIsoDateString,
 } from '@/lib/content/publish';
+import { LORE_IMAGE_TOKEN_TITLE, preparePostMarkdown } from '@/lib/markdown/postMarkdown';
 import rehypeDialogueQuotes from '@/lib/markdown/rehypeDialogueQuotes';
 import remarkFictionalLangTags from '@/lib/markdown/remarkFictionalLangTags';
 import remarkThinkingTags from '@/lib/markdown/remarkThinkingTags';
@@ -47,6 +52,8 @@ import {
   type ExtractedPalette,
   extractPaletteFromImage,
 } from '@/lib/theme/artPalette';
+import type { TtsHighlightRange } from '@/lib/tts/contract';
+import { deriveSpeechDocument, type SpeechDocument } from '@/lib/tts/speechDocument';
 import type { ParsedPost } from '../../lib/blog/parser';
 import { TtsPlayer } from './TtsPlayer';
 
@@ -229,8 +236,6 @@ function getPostDateString(post: ParsedPost): string | undefined {
   );
 }
 
-const LORE_IMAGE_TOKEN_TITLE = 'lore-token';
-
 const markdownSanitizeSchema = {
   ...defaultSchema,
   attributes: {
@@ -244,41 +249,6 @@ const markdownSanitizeSchema = {
     div: [...(defaultSchema.attributes?.div ?? []), ['data-thinking', 'inline', 'block']],
   },
 };
-
-function replaceLoreImageTokens(markdown: string): string {
-  return markdown.replace(
-    /\{\{\s*image\s*:\s*([^}]+?)\s*\}\}/gi,
-    (fullMatch, tokenValue: string) => {
-      const url = toLoreImageApiUrl(tokenValue);
-      if (!url) return fullMatch;
-
-      const raw = tokenValue.trim();
-      const basename = raw.split('/').filter(Boolean).pop() ?? 'image';
-      const alt =
-        basename
-          .replace(/\.[a-z0-9]+$/i, '')
-          .replace(/[_-]+/g, ' ')
-          .trim() || 'Lore image';
-
-      return `\n\n![${alt}](${url} "${LORE_IMAGE_TOKEN_TITLE}")\n\n`;
-    },
-  );
-}
-
-function normalizeThinkingTagFormatting(markdown: string): string {
-  return markdown.replace(
-    /<thinking>\s*\n((?:(?!\n\n)[\s\S])*?)\n\s*<\/thinking>/g,
-    '<thinking>$1</thinking>',
-  );
-}
-
-function replaceFictionalLangTagTokens(markdown: string): string {
-  return markdown
-    .replace(/<celestial:R>/gi, '<celestial reveal>')
-    .replace(/<abyssal:R>/gi, '<abyssal reveal>')
-    .replace(/<\/celestial:R>/gi, '</celestial>')
-    .replace(/<\/abyssal:R>/gi, '</abyssal>');
-}
 
 function lightenHexColor(hex: string, ratio: number): string {
   const normalized = hex.trim().replace(/^#/, '');
@@ -320,6 +290,143 @@ function buildTooltipText(
   return `${prefix}: ${story.title} - ${snippet}`;
 }
 
+interface NormalizedDomText {
+  text: string;
+  starts: Array<{ node: Text; offset: number }>;
+  ends: Array<{ node: Text; offset: number }>;
+}
+
+function normalizeSpeechDomText(
+  root: Element,
+  excludedDescendants: Set<Element>,
+): NormalizedDomText {
+  const textNodes: Text[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let current = walker.nextNode();
+  while (current) {
+    const textNode = current as Text;
+    const parent = textNode.parentElement;
+    if (
+      parent &&
+      !Array.from(excludedDescendants).some(
+        (excluded) => excluded === parent || excluded.contains(parent),
+      )
+    ) {
+      textNodes.push(textNode);
+    }
+    current = walker.nextNode();
+  }
+
+  let text = '';
+  const starts: NormalizedDomText['starts'] = [];
+  const ends: NormalizedDomText['ends'] = [];
+  let pendingWhitespaceStart: { node: Text; offset: number } | null = null;
+  let pendingWhitespaceEnd: { node: Text; offset: number } | null = null;
+
+  for (const node of textNodes) {
+    for (let offset = 0; offset < node.data.length; offset += 1) {
+      const character = node.data[offset] ?? '';
+      if (/\s/u.test(character)) {
+        pendingWhitespaceStart ??= { node, offset };
+        pendingWhitespaceEnd = { node, offset: offset + 1 };
+        continue;
+      }
+
+      if (pendingWhitespaceStart && pendingWhitespaceEnd && text.length > 0) {
+        text += ' ';
+        starts.push(pendingWhitespaceStart);
+        ends.push(pendingWhitespaceEnd);
+      }
+      pendingWhitespaceStart = null;
+      pendingWhitespaceEnd = null;
+      text += character;
+      starts.push({ node, offset });
+      ends.push({ node, offset: offset + 1 });
+    }
+  }
+
+  return { text, starts, ends };
+}
+
+function getSpeechDomCandidates(root: HTMLElement): NormalizedDomText[] {
+  const candidates: NormalizedDomText[] = [];
+  for (const element of root.querySelectorAll('p, li, pre')) {
+    if (element.closest('h1, h2, h3, h4, h5, h6, table')) continue;
+
+    if (element.tagName === 'PRE') {
+      const layerone = element.querySelector('code.language-layerone');
+      if (!layerone) continue;
+      candidates.push(normalizeSpeechDomText(layerone, new Set()));
+      continue;
+    }
+
+    if (
+      element.tagName === 'LI' &&
+      Array.from(element.children).some((child) => child.tagName === 'P')
+    ) {
+      continue;
+    }
+
+    const excluded = new Set<Element>();
+    for (const descendant of element.querySelectorAll('code, pre, img, table, ul, ol')) {
+      if (
+        element.tagName === 'LI' &&
+        (descendant.tagName === 'UL' || descendant.tagName === 'OL')
+      ) {
+        excluded.add(descendant);
+      } else if (descendant.tagName === 'CODE' || descendant.tagName === 'PRE') {
+        excluded.add(descendant);
+      }
+    }
+    candidates.push(normalizeSpeechDomText(element, excluded));
+  }
+  return candidates.filter((candidate) => candidate.text.length > 0);
+}
+
+function createSpeechHighlightRanges(
+  root: HTMLElement,
+  speechDocument: SpeechDocument,
+  activeRange: TtsHighlightRange,
+): Range[] {
+  const candidates = getSpeechDomCandidates(root);
+  const paragraphMappings: Array<NormalizedDomText | null> = [];
+  let candidateIndex = 0;
+
+  for (const paragraph of speechDocument.paragraphs) {
+    const expected = speechDocument.text.slice(paragraph.start, paragraph.end);
+    let mapping: NormalizedDomText | null = null;
+    while (candidateIndex < candidates.length) {
+      const candidate = candidates[candidateIndex] ?? null;
+      candidateIndex += 1;
+      if (candidate?.text === expected) {
+        mapping = candidate;
+        break;
+      }
+    }
+    paragraphMappings.push(mapping);
+  }
+
+  const ranges: Range[] = [];
+  speechDocument.paragraphs.forEach((paragraph, index) => {
+    const start = Math.max(activeRange.start, paragraph.start);
+    const end = Math.min(activeRange.end, paragraph.end);
+    const mapping = paragraphMappings[index];
+    if (!mapping || end <= start) return;
+
+    const relativeStart = start - paragraph.start;
+    const relativeEnd = end - paragraph.start;
+    const rangeStart = mapping.starts[relativeStart];
+    const rangeEnd = mapping.ends[relativeEnd - 1];
+    if (!rangeStart || !rangeEnd) return;
+
+    const range = document.createRange();
+    range.setStart(rangeStart.node, rangeStart.offset);
+    range.setEnd(rangeEnd.node, rangeEnd.offset);
+    ranges.push(range);
+  });
+  return ranges;
+}
+
 interface PostContentSectionProps {
   post: ParsedPost;
   isScheduledPreview: boolean;
@@ -331,6 +438,8 @@ interface PostContentSectionProps {
   thinkingColor: string;
   thinkingGlowColor: string;
   thinkingMutedColor: string;
+  speechDocument: SpeechDocument;
+  ttsHighlightRange: TtsHighlightRange | null;
 }
 
 function PostContentSection({
@@ -344,15 +453,19 @@ function PostContentSection({
   thinkingColor,
   thinkingGlowColor,
   thinkingMutedColor,
+  speechDocument,
+  ttsHighlightRange,
 }: PostContentSectionProps) {
   const contentRef = useRef<HTMLDivElement>(null);
+  const highlightNameBase = useMemo(
+    () => `tts-${post.filename.replace(/[^a-z0-9-]/gi, '-').toLowerCase()}`,
+    [post.filename],
+  );
+  const statementHighlightName = `${highlightNameBase}-statement`;
+  const chunkHighlightName = `${highlightNameBase}-chunk`;
 
   const markdownContent = useMemo(() => {
-    let cleaned = post.content;
-    cleaned = replaceLoreImageTokens(cleaned);
-    cleaned = normalizeThinkingTagFormatting(cleaned);
-    cleaned = replaceFictionalLangTagTokens(cleaned);
-    return cleaned;
+    return preparePostMarkdown(post.content);
   }, [post.content]);
   const markdownParts = useMemo(
     () => splitMarkdownSpeciesCareTokens(markdownContent),
@@ -644,6 +757,36 @@ function PostContentSection({
     };
   }, []);
 
+  useLayoutEffect(() => {
+    const root = contentRef.current;
+    if (typeof CSS === 'undefined') return;
+    const registry = (
+      CSS as unknown as {
+        highlights?: {
+          delete: (name: string) => void;
+          set: (name: string, value: unknown) => void;
+        };
+      }
+    ).highlights;
+    const HighlightConstructor = (
+      window as unknown as { Highlight?: new (...ranges: Range[]) => unknown }
+    ).Highlight;
+    const names = [statementHighlightName, chunkHighlightName];
+    names.forEach((name) => {
+      registry?.delete(name);
+    });
+
+    if (!root || !registry || !HighlightConstructor || !ttsHighlightRange) return;
+    const ranges = createSpeechHighlightRanges(root, speechDocument, ttsHighlightRange);
+    if (ranges.length === 0) return;
+    const name =
+      ttsHighlightRange.precision === 'statement' ? statementHighlightName : chunkHighlightName;
+    registry.set(name, new HighlightConstructor(...ranges));
+    return () => {
+      registry.delete(name);
+    };
+  }, [chunkHighlightName, speechDocument, statementHighlightName, ttsHighlightRange]);
+
   return (
     <>
       <Global
@@ -661,6 +804,14 @@ function PostContentSection({
             font-weight: normal;
             font-style: normal;
             font-display: swap;
+          }
+          ::highlight(${statementHighlightName}) {
+            background-color: rgba(250, 204, 21, 0.3);
+            color: inherit;
+          }
+          ::highlight(${chunkHighlightName}) {
+            background-color: rgba(125, 211, 252, 0.16);
+            color: inherit;
           }
         `}
       />
@@ -1138,6 +1289,11 @@ export function PostView({
   const [, setCoverIsLandscape] = useState<boolean | null>(null);
   const [ttsPrimaryColor, setTtsPrimaryColor] = useState<string | null>(null);
   const [titlePalette, setTitlePalette] = useState<ExtractedPalette>(DEFAULT_ART_PALETTE);
+  const [ttsHighlightRange, setTtsHighlightRange] = useState<TtsHighlightRange | null>(null);
+  const speechDocument = useMemo(() => deriveSpeechDocument(post.content), [post.content]);
+  const handleTtsHighlightChange = useCallback((range: TtsHighlightRange | null) => {
+    setTtsHighlightRange(range);
+  }, []);
 
   const dateString = useMemo(
     () => getPostDateString(post),
@@ -1298,6 +1454,10 @@ export function PostView({
   useEffect(() => {
     setEffectiveCoverImageUrl(transformedCoverImageUrl);
   }, [transformedCoverImageUrl]);
+
+  useEffect(() => {
+    if (ttsLocked || ttsFadingOut) setTtsHighlightRange(null);
+  }, [ttsFadingOut, ttsLocked]);
 
   useEffect(() => {
     if (!hasThinkingTitleFx) {
@@ -1600,19 +1760,20 @@ export function PostView({
 
           {!isScheduledPreview && (
             <Box sx={{ mb: 4, position: 'relative' }}>
-              <TtsPlayer
-                slug={post.filename.replace(/\.md$/, '')}
-                type={postType}
-                text={post.content}
-                onPrimaryColorChange={setTtsPrimaryColor}
-                coverImageUrl={effectiveCoverImageUrl}
-              />
-              {(ttsLocked || ttsFadingOut) && (
+              {!ttsLocked && !ttsFadingOut ? (
+                <TtsPlayer
+                  slug={post.filename.replace(/\.md$/, '')}
+                  type={postType}
+                  document={speechDocument}
+                  onPrimaryColorChange={setTtsPrimaryColor}
+                  onHighlightChange={handleTtsHighlightChange}
+                  coverImageUrl={effectiveCoverImageUrl}
+                />
+              ) : (
                 <Box
+                  aria-label="Audio unlocks with this post"
                   sx={{
-                    position: 'absolute',
-                    inset: 0,
-                    zIndex: 1,
+                    height: 44,
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
@@ -1661,6 +1822,8 @@ export function PostView({
               thinkingColor={thinkingColor}
               thinkingGlowColor={thinkingGlowColor}
               thinkingMutedColor={thinkingMutedColor}
+              speechDocument={speechDocument}
+              ttsHighlightRange={ttsHighlightRange}
             />,
             ttsPrimaryColor,
           )
@@ -1676,6 +1839,8 @@ export function PostView({
             thinkingColor={thinkingColor}
             thinkingGlowColor={thinkingGlowColor}
             thinkingMutedColor={thinkingMutedColor}
+            speechDocument={speechDocument}
+            ttsHighlightRange={ttsHighlightRange}
           />
         )}
       </Box>

--- a/components/blog/TtsPlayer.test.tsx
+++ b/components/blog/TtsPlayer.test.tsx
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { Window } from 'happy-dom';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { TTS_CACHE_VERSION, type TtsManifest } from '@/lib/tts/contract';
+import { deriveSpeechDocument, hashSpeechDocument } from '@/lib/tts/speechDocument';
 
 import { TtsPlayer } from './TtsPlayer';
 
@@ -12,7 +14,13 @@ interface StatusPayload {
   generated_chunks?: number;
   total_chunks?: number;
   playable?: boolean;
+  cache_version?: string;
+  content_hash?: string;
+  manifest?: TtsManifest;
 }
+
+const TEST_DOCUMENT = deriveSpeechDocument('Hello world');
+const TEST_CONTENT_HASH = await hashSpeechDocument(TEST_DOCUMENT);
 
 let testWindow: Window;
 let container: HTMLDivElement;
@@ -180,9 +188,18 @@ async function flushEffects() {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-async function renderPlayer() {
+async function renderPlayer(
+  onHighlightChange?: React.ComponentProps<typeof TtsPlayer>['onHighlightChange'],
+) {
   await act(async () => {
-    root.render(<TtsPlayer slug="shared-post" type="blog" text="Hello world" />);
+    root.render(
+      <TtsPlayer
+        slug="shared-post"
+        type="blog"
+        document={TEST_DOCUMENT}
+        onHighlightChange={onHighlightChange}
+      />,
+    );
     await flushEffects();
   });
 }
@@ -275,7 +292,41 @@ function payload(status: TtsState, partial?: Omit<StatusPayload, 'status'>): Sta
     generated_chunks: 0,
     total_chunks: 0,
     playable: false,
+    cache_version: TTS_CACHE_VERSION,
+    content_hash: TEST_CONTENT_HASH,
     ...partial,
+  };
+}
+
+function manifest(options: { timed: boolean }): TtsManifest {
+  return {
+    cache_version: TTS_CACHE_VERSION,
+    content_hash: TEST_CONTENT_HASH,
+    text_length: TEST_DOCUMENT.text.length,
+    paragraph_gap_ms: 500,
+    duration_ms: 1000,
+    chunks: [
+      {
+        index: 0,
+        start: 0,
+        end: TEST_DOCUMENT.text.length,
+        generated: true,
+        start_ms: 0,
+        end_ms: 1000,
+      },
+    ],
+    statements: options.timed
+      ? [
+          {
+            start: 0,
+            end: 5,
+            paragraph: 0,
+            chunk: 0,
+            start_ms: 0,
+            end_ms: 1000,
+          },
+        ]
+      : [],
   };
 }
 
@@ -352,18 +403,26 @@ describe('TtsPlayer', () => {
     expect(
       await waitForElement(() => getVisibleReadyButton('Play'), 'Expected visible Play button'),
     ).not.toBeNull();
-    expect(lastAudio?.src.endsWith('/api/tts/audio/blog/shared-post')).toBe(true);
+    expect(lastAudio?.src).toContain('/api/tts/audio/blog/shared-post?');
+    expect(lastAudio?.src).toContain(`content_hash=${TEST_CONTENT_HASH}`);
+    expect(lastAudio?.src).toContain(`cache_version=${TTS_CACHE_VERSION}`);
     expect(lastAudio?.playCalls).toBe(0);
     expect(clearIntervalCalls).toBeGreaterThan(0);
   });
 
   test('starts streaming playback after listen when generation is playable', async () => {
-    setFetchMock(async (url) => {
+    setFetchMock(async (url, init) => {
       if (url.includes('/api/tts/status')) {
         return jsonResponse(payload('not_generated'));
       }
 
-      if (url.endsWith('/api/tts/generate')) {
+      if (url.includes('/api/tts/generate?')) {
+        expect(url).toContain(`content_hash=${TEST_CONTENT_HASH}`);
+        expect(url).toContain(`cache_version=${TTS_CACHE_VERSION}`);
+        const requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        expect(requestBody.content_hash).toBe(TEST_CONTENT_HASH);
+        expect(requestBody.cache_version).toBe(TTS_CACHE_VERSION);
+        expect(requestBody.document).toEqual(TEST_DOCUMENT);
         return jsonResponse(
           payload('generating', {
             generated_chunks: 3,
@@ -453,7 +512,7 @@ describe('TtsPlayer', () => {
         return jsonResponse(statuses.shift() ?? payload('not_generated'));
       }
 
-      if (url.endsWith('/api/tts/generate')) {
+      if (url.includes('/api/tts/generate?')) {
         return new Promise<Response>((resolve) => {
           resolveGenerate = resolve;
         });
@@ -515,6 +574,75 @@ describe('TtsPlayer', () => {
     ).not.toBeNull();
     expect(getVisibleReadyButton('Pause')).toBeNull();
     expect(lastAudio?.playCalls).toBe(0);
+  });
+
+  test('reports exact statement offsets from a completed timing manifest', async () => {
+    const highlights: Array<{ start: number; end: number; precision: string } | null> = [];
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) {
+        return jsonResponse(
+          payload('ready', {
+            generated_chunks: 1,
+            total_chunks: 1,
+            playable: true,
+            manifest: manifest({ timed: true }),
+          }),
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer((range) => highlights.push(range));
+    const playButton = await waitForElement(
+      () => getVisibleReadyButton('Play'),
+      'Expected ready Play button',
+    );
+
+    await act(async () => {
+      playButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(highlights.at(-1)).toEqual({ start: 0, end: 5, precision: 'statement' });
+  });
+
+  test('reports the chunk range while progressive timing is not available yet', async () => {
+    const highlights: Array<{ start: number; end: number; precision: string } | null> = [];
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) return jsonResponse(payload('not_generated'));
+      if (url.includes('/api/tts/generate?')) {
+        return jsonResponse(
+          payload('generating', {
+            generated_chunks: 3,
+            total_chunks: 3,
+            playable: true,
+            manifest: manifest({ timed: false }),
+          }),
+          202,
+        );
+      }
+      if (url.includes('/api/tts/chunk/blog/shared-post/0')) return wavResponse();
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer((range) => highlights.push(range));
+    const listenButton = getVisibleListenButton();
+    if (!listenButton) throw new Error('Expected visible listen button');
+
+    await act(async () => {
+      listenButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    await waitForCondition(
+      () => highlights.some((range) => range?.precision === 'chunk'),
+      'Expected chunk fallback highlight',
+    );
+    expect(highlights.at(-1)).toEqual({
+      start: 0,
+      end: TEST_DOCUMENT.text.length,
+      precision: 'chunk',
+    });
   });
 
   test('renders safe time labels when audio metadata is non-finite', async () => {

--- a/components/blog/TtsPlayer.test.tsx
+++ b/components/blog/TtsPlayer.test.tsx
@@ -373,6 +373,100 @@ afterEach(async () => {
 });
 
 describe('TtsPlayer', () => {
+  test('waits for delayed hashing before polling a non-playable generation to ready', async () => {
+    const originalDigest = crypto.subtle.digest;
+    const digestBytes = new Uint8Array(
+      TEST_CONTENT_HASH.match(/.{2}/g)?.map((byte) => Number.parseInt(byte, 16)) ?? [],
+    );
+    let resolveDigest: (() => void) | null = null;
+    let statusRequests = 0;
+
+    crypto.subtle.digest = (() =>
+      new Promise<ArrayBuffer>((resolve) => {
+        resolveDigest = () => resolve(digestBytes.buffer);
+      })) as typeof crypto.subtle.digest;
+
+    try {
+      setFetchMock(async (url) => {
+        if (url.includes('/api/tts/status')) {
+          statusRequests += 1;
+          if (statusRequests === 1) return jsonResponse(payload('not_generated'));
+          if (statusRequests === 2) {
+            return jsonResponse(
+              payload('generating', {
+                generated_chunks: 2,
+                total_chunks: 10,
+                playable: false,
+              }),
+            );
+          }
+          return jsonResponse(
+            payload('ready', { generated_chunks: 10, total_chunks: 10, playable: true }),
+          );
+        }
+
+        if (url.includes('/api/tts/generate?')) {
+          return jsonResponse(
+            payload('generating', {
+              generated_chunks: 1,
+              total_chunks: 10,
+              playable: false,
+            }),
+            202,
+          );
+        }
+
+        throw new Error(`Unexpected fetch: ${url}`);
+      });
+
+      await renderPlayer();
+
+      expect(intervalCallback).toBeNull();
+      expect(statusRequests).toBe(0);
+
+      await act(async () => {
+        resolveDigest?.();
+        await flushEffects();
+      });
+
+      await waitForCondition(() => statusRequests === 1, 'Expected initial hashed status request');
+
+      const listenButton = getVisibleListenButton();
+      if (!(listenButton instanceof testWindow.HTMLElement)) {
+        throw new Error('Expected visible listen button');
+      }
+
+      await act(async () => {
+        listenButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+        await flushEffects();
+      });
+
+      expect(
+        await waitForElement(getVisibleGeneratingBar, 'Expected generating bar'),
+      ).not.toBeNull();
+
+      await act(async () => {
+        intervalCallback?.();
+        await flushEffects();
+      });
+
+      expect(statusRequests).toBe(2);
+      expect(getVisibleGeneratingBar()).not.toBeNull();
+
+      await act(async () => {
+        intervalCallback?.();
+        await flushEffects();
+      });
+
+      expect(
+        await waitForElement(() => getVisibleReadyButton('Play'), 'Expected ready Play button'),
+      ).not.toBeNull();
+      expect(statusRequests).toBe(3);
+    } finally {
+      crypto.subtle.digest = originalDigest;
+    }
+  });
+
   test('shows the generating bar immediately when another visitor already started generation', async () => {
     setFetchMock(async (url) => {
       if (url.includes('/api/tts/status')) {

--- a/components/blog/TtsPlayer.test.tsx
+++ b/components/blog/TtsPlayer.test.tsx
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { Window } from 'happy-dom';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { TTS_CACHE_VERSION, TTS_OFFSET_UNIT, type TtsManifest } from '@/lib/tts/contract';
+import {
+  TTS_CACHE_VERSION,
+  TTS_OFFSET_UNIT,
+  type TtsHighlightRange,
+  type TtsManifest,
+} from '@/lib/tts/contract';
 import { deriveSpeechDocument, hashSpeechDocument } from '@/lib/tts/speechDocument';
 
 import { TtsPlayer } from './TtsPlayer';
@@ -254,7 +259,7 @@ function getVisibleListenButton() {
   );
 }
 
-function getVisibleReadyButton(label: 'Play' | 'Pause') {
+function getVisibleReadyButton(label: 'Play' | 'Pause' | 'Stop') {
   const activeContainer = getAllElements(container).find(
     (element) => element.getAttribute('aria-hidden') === 'false',
   );
@@ -298,14 +303,15 @@ function payload(status: TtsState, partial?: Omit<StatusPayload, 'status'>): Sta
   };
 }
 
-function manifest(options: { timed: boolean }): TtsManifest {
+function manifest(options: { timed: boolean; statementDurationMs?: number }): TtsManifest {
+  const statementDurationMs = options.statementDurationMs ?? 1000;
   return {
     cache_version: TTS_CACHE_VERSION,
     content_hash: TEST_CONTENT_HASH,
     offset_unit: TTS_OFFSET_UNIT,
     text_length: TEST_DOCUMENT.text.length,
     paragraph_gap_ms: 500,
-    duration_ms: 1000,
+    duration_ms: statementDurationMs,
     chunks: [
       {
         index: 0,
@@ -313,7 +319,7 @@ function manifest(options: { timed: boolean }): TtsManifest {
         end: TEST_DOCUMENT.text.length,
         generated: true,
         start_ms: 0,
-        end_ms: 1000,
+        end_ms: statementDurationMs,
       },
     ],
     statements: options.timed
@@ -324,7 +330,7 @@ function manifest(options: { timed: boolean }): TtsManifest {
             paragraph: 0,
             chunk: 0,
             start_ms: 0,
-            end_ms: 1000,
+            end_ms: statementDurationMs,
           },
         ]
       : [],
@@ -604,7 +610,120 @@ describe('TtsPlayer', () => {
       await flushEffects();
     });
 
-    expect(highlights.at(-1)).toEqual({ start: 0, end: 5, precision: 'statement' });
+    expect(highlights.at(-1)).toEqual({
+      start: 0,
+      end: 5,
+      precision: 'statement',
+      handoff_ms: 250,
+    });
+  });
+
+  test('uses ten percent of statement duration for the visual handoff', async () => {
+    const highlights: Array<TtsHighlightRange | null> = [];
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) {
+        return jsonResponse(
+          payload('ready', {
+            generated_chunks: 1,
+            total_chunks: 1,
+            playable: true,
+            manifest: manifest({ timed: true, statementDurationMs: 10_000 }),
+          }),
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer((range) => highlights.push(range));
+    const playButton = await waitForElement(
+      () => getVisibleReadyButton('Play'),
+      'Expected ready Play button',
+    );
+
+    await act(async () => {
+      playButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(highlights.at(-1)?.handoff_ms).toBe(1000);
+  });
+
+  test('caps the statement handoff at three seconds', async () => {
+    const highlights: Array<TtsHighlightRange | null> = [];
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) {
+        return jsonResponse(
+          payload('ready', {
+            generated_chunks: 1,
+            total_chunks: 1,
+            playable: true,
+            manifest: manifest({ timed: true, statementDurationMs: 60_000 }),
+          }),
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer((range) => highlights.push(range));
+    const playButton = await waitForElement(
+      () => getVisibleReadyButton('Play'),
+      'Expected ready Play button',
+    );
+
+    await act(async () => {
+      playButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+
+    expect(highlights.at(-1)?.handoff_ms).toBe(3000);
+  });
+
+  test('keeps the current highlight paused and clears it on stop', async () => {
+    const highlights: Array<TtsHighlightRange | null> = [];
+    setFetchMock(async (url) => {
+      if (url.includes('/api/tts/status')) {
+        return jsonResponse(
+          payload('ready', {
+            generated_chunks: 1,
+            total_chunks: 1,
+            playable: true,
+            manifest: manifest({ timed: true }),
+          }),
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await renderPlayer((range) => highlights.push(range));
+    const playButton = await waitForElement(
+      () => getVisibleReadyButton('Play'),
+      'Expected ready Play button',
+    );
+
+    await act(async () => {
+      playButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+      if (!lastAudio) throw new Error('Expected audio instance');
+      lastAudio.currentTime = 0.5;
+      lastAudio.dispatch('timeupdate');
+      await flushEffects();
+    });
+    const activeHighlight = highlights.at(-1);
+
+    const pauseButton = getVisibleReadyButton('Pause');
+    if (!pauseButton) throw new Error('Expected Pause button');
+    await act(async () => {
+      pauseButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    expect(highlights.at(-1)).toEqual(activeHighlight);
+
+    const stopButton = getVisibleReadyButton('Stop');
+    if (!stopButton) throw new Error('Expected Stop button');
+    await act(async () => {
+      stopButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+      await flushEffects();
+    });
+    expect(highlights.at(-1)).toBeNull();
   });
 
   test('reports the chunk range while progressive timing is not available yet', async () => {
@@ -643,6 +762,7 @@ describe('TtsPlayer', () => {
       start: 0,
       end: TEST_DOCUMENT.text.length,
       precision: 'chunk',
+      handoff_ms: 350,
     });
   });
 

--- a/components/blog/TtsPlayer.test.tsx
+++ b/components/blog/TtsPlayer.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { Window } from 'happy-dom';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { TTS_CACHE_VERSION, type TtsManifest } from '@/lib/tts/contract';
+import { TTS_CACHE_VERSION, TTS_OFFSET_UNIT, type TtsManifest } from '@/lib/tts/contract';
 import { deriveSpeechDocument, hashSpeechDocument } from '@/lib/tts/speechDocument';
 
 import { TtsPlayer } from './TtsPlayer';
@@ -302,6 +302,7 @@ function manifest(options: { timed: boolean }): TtsManifest {
   return {
     cache_version: TTS_CACHE_VERSION,
     content_hash: TEST_CONTENT_HASH,
+    offset_unit: TTS_OFFSET_UNIT,
     text_length: TEST_DOCUMENT.text.length,
     paragraph_gap_ms: 500,
     duration_ms: 1000,

--- a/components/blog/TtsPlayer.tsx
+++ b/components/blog/TtsPlayer.tsx
@@ -26,6 +26,19 @@ type StatusSource = 'poll' | 'generate' | 'init';
 const STATUS_POLL_INTERVAL_MS = 3000;
 const CHUNK_RETRY_DELAY_MS = 800;
 const MIN_PLAYABLE_CHUNKS = 3;
+const COARSE_HIGHLIGHT_HANDOFF_MS = 350;
+const MIN_STATEMENT_HANDOFF_MS = 250;
+const MAX_STATEMENT_HANDOFF_MS = 3000;
+
+function getStatementHandoffMs(startMs: number, endMs: number): number {
+  const duration = Number.isFinite(startMs) && Number.isFinite(endMs) ? endMs - startMs : 0;
+  return Math.round(
+    Math.min(
+      MAX_STATEMENT_HANDOFF_MS,
+      Math.max(MIN_STATEMENT_HANDOFF_MS, Math.max(0, duration) * 0.1),
+    ),
+  );
+}
 
 interface TtsPlayerProps {
   slug: string;
@@ -259,7 +272,12 @@ export function TtsPlayer({
         (candidate) => currentMs >= candidate.start_ms && currentMs < candidate.end_ms,
       );
       if (statement) {
-        emitHighlight({ start: statement.start, end: statement.end, precision: 'statement' });
+        emitHighlight({
+          start: statement.start,
+          end: statement.end,
+          precision: 'statement',
+          handoff_ms: getStatementHandoffMs(statement.start_ms, statement.end_ms),
+        });
         return;
       }
 
@@ -268,7 +286,12 @@ export function TtsPlayer({
           ? null
           : manifest.chunks.find((candidate) => candidate.index === chunkIndex);
       if (chunk) {
-        emitHighlight({ start: chunk.start, end: chunk.end, precision: 'chunk' });
+        emitHighlight({
+          start: chunk.start,
+          end: chunk.end,
+          precision: 'chunk',
+          handoff_ms: COARSE_HIGHLIGHT_HANDOFF_MS,
+        });
         return;
       }
       emitHighlight(null);

--- a/components/blog/TtsPlayer.tsx
+++ b/components/blog/TtsPlayer.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/theme/artPalette';
 import {
   TTS_CACHE_VERSION,
+  TTS_OFFSET_UNIT,
   type TtsHighlightRange,
   type TtsManifest,
   type TtsState,
@@ -41,6 +42,7 @@ function parseManifest(raw: unknown, contentHash: string): TtsManifest | undefin
   if (
     value.cache_version !== TTS_CACHE_VERSION ||
     value.content_hash !== contentHash ||
+    value.offset_unit !== TTS_OFFSET_UNIT ||
     !Array.isArray(value.chunks) ||
     !Array.isArray(value.statements)
   ) {

--- a/components/blog/TtsPlayer.tsx
+++ b/components/blog/TtsPlayer.tsx
@@ -9,8 +9,16 @@ import {
   type ExtractedPalette,
   extractPaletteFromImage,
 } from '@/lib/theme/artPalette';
+import {
+  TTS_CACHE_VERSION,
+  type TtsHighlightRange,
+  type TtsManifest,
+  type TtsState,
+  type TtsStatusPayload,
+  ttsIdentityQuery,
+} from '@/lib/tts/contract';
+import { hashSpeechDocument, type SpeechDocument } from '@/lib/tts/speechDocument';
 
-type TtsState = 'not_generated' | 'generating' | 'ready';
 type PlaybackState = 'stopped' | 'playing' | 'paused';
 type StatusSource = 'poll' | 'generate' | 'init';
 
@@ -21,25 +29,34 @@ const MIN_PLAYABLE_CHUNKS = 3;
 interface TtsPlayerProps {
   slug: string;
   type: 'blog' | 'lore';
-  text: string;
+  document: SpeechDocument;
   coverImageUrl?: string;
   onPrimaryColorChange?: (color: string) => void;
+  onHighlightChange?: (range: TtsHighlightRange | null) => void;
 }
 
-interface TtsStatusPayload {
-  status: TtsState;
-  generated_chunks: number;
-  total_chunks: number;
-  playable: boolean;
+function parseManifest(raw: unknown, contentHash: string): TtsManifest | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const value = raw as Record<string, unknown>;
+  if (
+    value.cache_version !== TTS_CACHE_VERSION ||
+    value.content_hash !== contentHash ||
+    !Array.isArray(value.chunks) ||
+    !Array.isArray(value.statements)
+  ) {
+    return undefined;
+  }
+  return value as unknown as TtsManifest;
 }
 
-function parseStatusPayload(raw: unknown): TtsStatusPayload | null {
+function parseStatusPayload(raw: unknown, contentHash: string): TtsStatusPayload | null {
   if (!raw || typeof raw !== 'object') return null;
   const value = raw as Record<string, unknown>;
   const status = value.status;
   if (status !== 'not_generated' && status !== 'generating' && status !== 'ready') {
     return null;
   }
+  if (value.cache_version !== TTS_CACHE_VERSION || value.content_hash !== contentHash) return null;
 
   const parsedGenerated = Number(value.generated_chunks ?? 0);
   const parsedTotal = Number(value.total_chunks ?? 0);
@@ -56,6 +73,9 @@ function parseStatusPayload(raw: unknown): TtsStatusPayload | null {
     generated_chunks: boundedGenerated,
     total_chunks: totalChunks,
     playable,
+    cache_version: TTS_CACHE_VERSION,
+    content_hash: contentHash,
+    manifest: parseManifest(value.manifest, contentHash),
   };
 }
 
@@ -89,9 +109,10 @@ function getTimelineState(audio: HTMLAudioElement) {
 export function TtsPlayer({
   slug,
   type,
-  text,
+  document,
   coverImageUrl,
   onPrimaryColorChange,
+  onHighlightChange,
 }: TtsPlayerProps) {
   const [state, setState] = useState<TtsState>('not_generated');
   const [playback, setPlayback] = useState<PlaybackState>('stopped');
@@ -101,6 +122,7 @@ export function TtsPlayer({
   const [isGenerationActive, setIsGenerationActive] = useState(false);
   const [canSeek, setCanSeek] = useState(false);
   const [colors, setColors] = useState<ExtractedPalette>(DEFAULT_ART_PALETTE);
+  const [contentHash, setContentHash] = useState<string | null>(null);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -120,9 +142,27 @@ export function TtsPlayer({
   const totalChunksRef = useRef(0);
   const streamingOffsetRef = useRef(0);
   const chunkDurationsRef = useRef<Map<number, number>>(new Map());
+  const manifestRef = useRef<TtsManifest | null>(null);
+  const highlightKeyRef = useRef('');
 
-  const sharedAudioUrl = `/api/tts/audio/${encodeURIComponent(type)}/${encodeURIComponent(slug)}`;
-  const sharedChunkBaseUrl = `/api/tts/chunk/${encodeURIComponent(type)}/${encodeURIComponent(slug)}`;
+  const identityQuery = contentHash ? ttsIdentityQuery(contentHash) : '';
+  const sharedAudioUrl = contentHash
+    ? `/api/tts/audio/${encodeURIComponent(type)}/${encodeURIComponent(slug)}?${identityQuery}`
+    : '';
+  const sharedChunkBaseUrl = contentHash
+    ? `/api/tts/chunk/${encodeURIComponent(type)}/${encodeURIComponent(slug)}`
+    : '';
+
+  useEffect(() => {
+    let active = true;
+    setContentHash(null);
+    void hashSpeechDocument(document).then((hash) => {
+      if (active) setContentHash(hash);
+    });
+    return () => {
+      active = false;
+    };
+  }, [document]);
 
   useEffect(() => {
     playbackRef.current = playback;
@@ -190,6 +230,50 @@ export function TtsPlayer({
     return total;
   }, []);
 
+  const emitHighlight = useCallback(
+    (range: TtsHighlightRange | null) => {
+      const key = range ? `${range.start}:${range.end}:${range.precision}` : '';
+      if (key === highlightKeyRef.current) return;
+      highlightKeyRef.current = key;
+      onHighlightChange?.(range);
+    },
+    [onHighlightChange],
+  );
+
+  const syncHighlight = useCallback(
+    (absoluteSeconds: number, chunkIndex: number | null) => {
+      if (playbackRef.current === 'stopped') {
+        emitHighlight(null);
+        return;
+      }
+      const manifest = manifestRef.current;
+      if (!manifest || !Number.isFinite(absoluteSeconds)) {
+        emitHighlight(null);
+        return;
+      }
+
+      const currentMs = absoluteSeconds * 1000;
+      const statement = manifest.statements.find(
+        (candidate) => currentMs >= candidate.start_ms && currentMs < candidate.end_ms,
+      );
+      if (statement) {
+        emitHighlight({ start: statement.start, end: statement.end, precision: 'statement' });
+        return;
+      }
+
+      const chunk =
+        chunkIndex === null
+          ? null
+          : manifest.chunks.find((candidate) => candidate.index === chunkIndex);
+      if (chunk) {
+        emitHighlight({ start: chunk.start, end: chunk.end, precision: 'chunk' });
+        return;
+      }
+      emitHighlight(null);
+    },
+    [emitHighlight],
+  );
+
   const syncTimelineFromAudio = useCallback(() => {
     const audio = audioRef.current;
     if (!audio) return;
@@ -199,17 +283,28 @@ export function TtsPlayer({
       setDuration(timeline.duration);
       setCurrentTime(timeline.currentTime);
       setProgress(timeline.progress);
+      syncHighlight(timeline.currentTime, null);
       return;
     }
 
     const activeIndex = currentChunkIndexRef.current;
+    const manifestChunk =
+      activeIndex === null
+        ? null
+        : manifestRef.current?.chunks.find((chunk) => chunk.index === activeIndex);
     const baseOffset =
-      activeIndex !== null ? sumKnownChunkDurations(activeIndex) : streamingOffsetRef.current;
+      manifestChunk?.start_ms !== undefined
+        ? manifestChunk.start_ms / 1000
+        : activeIndex !== null
+          ? sumKnownChunkDurations(activeIndex)
+          : streamingOffsetRef.current;
 
     const chunkDuration = getSafeDuration(audio.duration);
     const chunkCurrent = getSafeCurrentTime(audio.currentTime, chunkDuration);
     const totalCurrent = baseOffset + chunkCurrent;
-    const generatedDuration = sumKnownChunkDurations(generatedChunksRef.current);
+    const generatedDuration =
+      (manifestRef.current?.duration_ms ?? 0) / 1000 ||
+      sumKnownChunkDurations(generatedChunksRef.current);
     const totalDuration = Math.max(totalCurrent, generatedDuration);
     const nextProgress =
       totalDuration > 0 ? Math.min(100, Math.max(0, (totalCurrent / totalDuration) * 100)) : 0;
@@ -217,7 +312,8 @@ export function TtsPlayer({
     setDuration(totalDuration);
     setCurrentTime(totalCurrent);
     setProgress(nextProgress);
-  }, [sumKnownChunkDurations]);
+    syncHighlight(totalCurrent, activeIndex);
+  }, [sumKnownChunkDurations, syncHighlight]);
 
   const loadReadyAudio = useCallback(
     async (autoplay = false) => {
@@ -238,6 +334,7 @@ export function TtsPlayer({
       setDuration(0);
       setCurrentTime(0);
       setProgress(0);
+      emitHighlight(null);
 
       if (!autoplay && !audio.paused) {
         audio.pause();
@@ -257,7 +354,7 @@ export function TtsPlayer({
         setPlayback('stopped');
       }
     },
-    [clearChunkRetry, revokeCurrentChunkUrl, sharedAudioUrl],
+    [clearChunkRetry, emitHighlight, revokeCurrentChunkUrl, sharedAudioUrl],
   );
 
   const tryStartChunkPlayback = useCallback(
@@ -284,9 +381,13 @@ export function TtsPlayer({
       }
 
       try {
-        const response = await fetch(`${sharedChunkBaseUrl}/${chunkIndex}`, {
-          cache: 'no-store',
-        });
+        if (!contentHash) return false;
+        const response = await fetch(
+          `${sharedChunkBaseUrl}/${chunkIndex}?${ttsIdentityQuery(contentHash)}`,
+          {
+            cache: 'no-store',
+          },
+        );
         if (!response.ok) {
           if (
             (response.status === 404 || response.status === 425) &&
@@ -335,6 +436,7 @@ export function TtsPlayer({
     },
     [
       clearChunkRetry,
+      contentHash,
       revokeCurrentChunkUrl,
       sharedChunkBaseUrl,
       sumKnownChunkDurations,
@@ -383,6 +485,7 @@ export function TtsPlayer({
 
   const applyStatus = useCallback(
     async (statusData: TtsStatusPayload, source: StatusSource): Promise<TtsState> => {
+      if (statusData.manifest) manifestRef.current = statusData.manifest;
       generatedChunksRef.current = statusData.generated_chunks;
       totalChunksRef.current = statusData.total_chunks;
       generationCompleteRef.current = statusData.status === 'ready';
@@ -432,21 +535,22 @@ export function TtsPlayer({
 
   const checkStatus = useCallback(
     async (source: StatusSource = 'poll') => {
+      if (!contentHash) return null;
       try {
         const response = await fetch(
-          `/api/tts/status?slug=${encodeURIComponent(slug)}&type=${encodeURIComponent(type)}`,
+          `/api/tts/status?slug=${encodeURIComponent(slug)}&type=${encodeURIComponent(type)}&${ttsIdentityQuery(contentHash)}`,
           { cache: 'no-store' },
         );
         if (!response.ok) return null;
         const raw = await response.json();
-        const payload = parseStatusPayload(raw);
+        const payload = parseStatusPayload(raw, contentHash);
         if (!payload) return null;
         return await applyStatus(payload, source);
       } catch {
         return null;
       }
     },
-    [applyStatus, slug, type],
+    [applyStatus, contentHash, slug, type],
   );
 
   const startPolling = useCallback(() => {
@@ -457,6 +561,7 @@ export function TtsPlayer({
   }, [checkStatus]);
 
   const handleGenerate = useCallback(async () => {
+    if (!contentHash) return;
     setState('generating');
     setIsGenerationActive(true);
     setCanSeek(false);
@@ -465,15 +570,21 @@ export function TtsPlayer({
     generateRequestInFlightRef.current = true;
 
     try {
-      const response = await fetch('/api/tts/generate', {
+      const response = await fetch(`/api/tts/generate?${ttsIdentityQuery(contentHash)}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text, slug, type }),
+        body: JSON.stringify({
+          document,
+          slug,
+          type,
+          content_hash: contentHash,
+          cache_version: TTS_CACHE_VERSION,
+        }),
       });
 
       let payload: TtsStatusPayload | null = null;
       try {
-        payload = parseStatusPayload(await response.json());
+        payload = parseStatusPayload(await response.json(), contentHash);
       } catch {
         payload = null;
       }
@@ -498,7 +609,7 @@ export function TtsPlayer({
     } finally {
       generateRequestInFlightRef.current = false;
     }
-  }, [applyStatus, checkStatus, slug, startPolling, text, type]);
+  }, [applyStatus, checkStatus, contentHash, document, slug, startPolling, type]);
 
   const handlePlay = useCallback(() => {
     const audio = audioRef.current;
@@ -551,8 +662,10 @@ export function TtsPlayer({
       nextChunkIndexRef.current = 0;
       streamingOffsetRef.current = 0;
       setPlayback('stopped');
+      playbackRef.current = 'stopped';
       setCurrentTime(0);
       setProgress(0);
+      emitHighlight(null);
       if (generationCompleteRef.current) {
         void loadReadyAudio(false);
       }
@@ -562,9 +675,11 @@ export function TtsPlayer({
     audio.pause();
     audio.currentTime = 0;
     setPlayback('stopped');
+    playbackRef.current = 'stopped';
     setCurrentTime(0);
     setProgress(0);
-  }, [clearChunkRetry, loadReadyAudio]);
+    emitHighlight(null);
+  }, [clearChunkRetry, emitHighlight, loadReadyAudio]);
 
   useEffect(() => {
     const audio = new Audio();
@@ -601,12 +716,15 @@ export function TtsPlayer({
     };
 
     const handlePlayingEvent = () => {
+      playbackRef.current = 'playing';
       setPlayback('playing');
       syncTimelineFromAudio();
     };
 
     const handlePauseEvent = () => {
-      setPlayback(audio.currentTime > 0 ? 'paused' : 'stopped');
+      const nextPlayback = audio.currentTime > 0 ? 'paused' : 'stopped';
+      playbackRef.current = nextPlayback;
+      setPlayback(nextPlayback);
       syncTimelineFromAudio();
     };
 
@@ -631,6 +749,7 @@ export function TtsPlayer({
         ) {
           streamingActiveRef.current = false;
           streamingShouldPlayRef.current = false;
+          playbackRef.current = 'stopped';
           setPlayback('stopped');
           setCurrentTime(0);
           setProgress(0);
@@ -642,9 +761,11 @@ export function TtsPlayer({
         return;
       }
 
+      playbackRef.current = 'stopped';
       setPlayback('stopped');
       setCurrentTime(0);
       setProgress(0);
+      emitHighlight(null);
     };
 
     audio.addEventListener('loadedmetadata', handleLoadedMetadata);
@@ -666,9 +787,11 @@ export function TtsPlayer({
       stopPolling();
       clearChunkRetry();
       revokeCurrentChunkUrl();
+      emitHighlight(null);
     };
   }, [
     clearChunkRetry,
+    emitHighlight,
     loadReadyAudio,
     revokeCurrentChunkUrl,
     stopPolling,

--- a/components/blog/TtsPlayer.tsx
+++ b/components/blog/TtsPlayer.tsx
@@ -825,6 +825,11 @@ export function TtsPlayer({
   ]);
 
   useEffect(() => {
+    if (!contentHash) {
+      stopPolling();
+      return;
+    }
+
     let isActive = true;
 
     const syncInitialStatus = async () => {
@@ -837,8 +842,9 @@ export function TtsPlayer({
 
     return () => {
       isActive = false;
+      stopPolling();
     };
-  }, [checkStatus, startPolling]);
+  }, [checkStatus, contentHash, startPolling, stopPolling]);
 
   const gradientBg = useMemo(
     () =>

--- a/lib/content/test-posts.ts
+++ b/lib/content/test-posts.ts
@@ -54,7 +54,7 @@ const shouldStayStandardMarkdownOnly = true;
 \`\`\`
 
 \`\`\`layerone
-BLOG TEST SIGNAL :: STANDARD MARKDOWN ONLY
+*BLOG TEST SIGNAL* :: STANDARD MARKDOWN ONLY
 \`\`\`
 
 ## Image
@@ -133,7 +133,7 @@ THIS ORDINARY CODE MUST NOT BE SPOKEN
 \`\`\`
 
 \`\`\`layerone
-LORE TEST SIGNAL :: TOKEN SYSTEMS ACTIVE
+*LORE TEST SIGNAL* :: TOKEN SYSTEMS ACTIVE
 \`\`\`
 
 ## Standard Markdown Image

--- a/lib/content/test-posts.ts
+++ b/lib/content/test-posts.ts
@@ -11,7 +11,9 @@ export const blogRendererTestPost: ParsedPost = {
     date: '2026-05-25',
     author: 'Midori AI Test Fixture',
   },
-  content: `# Blog Markdown Coverage
+  content: `> **Disclaimer:** This opening fixture disclaimer is visible but must not be spoken by TTS.
+
+# Blog Markdown Coverage
 
 This page is a hidden renderer fixture for normal blog posts. It should cover standard markdown behavior without using lore-only brace tokens.
 
@@ -102,6 +104,8 @@ story_order: 9999
 episode_label: Renderer Test
 ---
 
+> **Disclaimer:** This opening fixture disclaimer is visible but must not be spoken by TTS.
+
 # Lore Markdown Coverage
 
 This page is a hidden renderer fixture for lore posts. It intentionally includes lore-only token systems that normal blog posts should not rely on.
@@ -123,6 +127,10 @@ This page is a hidden renderer fixture for lore posts. It intentionally includes
 | Inline code | \`story_order: 9999\` remains legible |
 
 > This blockquote checks lore prose styling in the same renderer used by real lore posts.
+
+\`\`\`txt
+THIS ORDINARY CODE MUST NOT BE SPOKEN
+\`\`\`
 
 \`\`\`layerone
 LORE TEST SIGNAL :: TOKEN SYSTEMS ACTIVE

--- a/lib/markdown/postMarkdown.ts
+++ b/lib/markdown/postMarkdown.ts
@@ -1,0 +1,44 @@
+import { toLoreImageApiUrl } from '@/lib/content/imageUrl';
+
+export const LORE_IMAGE_TOKEN_TITLE = 'lore-token';
+
+export function replaceLoreImageTokens(markdown: string): string {
+  return markdown.replace(
+    /\{\{\s*image\s*:\s*([^}]+?)\s*\}\}/gi,
+    (fullMatch, tokenValue: string) => {
+      const url = toLoreImageApiUrl(tokenValue);
+      if (!url) return fullMatch;
+
+      const raw = tokenValue.trim();
+      const basename = raw.split('/').filter(Boolean).pop() ?? 'image';
+      const alt =
+        basename
+          .replace(/\.[a-z0-9]+$/i, '')
+          .replace(/[_-]+/g, ' ')
+          .trim() || 'Lore image';
+
+      return `\n\n![${alt}](${url} "${LORE_IMAGE_TOKEN_TITLE}")\n\n`;
+    },
+  );
+}
+
+export function normalizeThinkingTagFormatting(markdown: string): string {
+  return markdown.replace(
+    /<thinking>\s*\n((?:(?!\n\n)[\s\S])*?)\n\s*<\/thinking>/g,
+    '<thinking>$1</thinking>',
+  );
+}
+
+export function replaceFictionalLangTagTokens(markdown: string): string {
+  return markdown
+    .replace(/<celestial:R>/gi, '<celestial reveal>')
+    .replace(/<abyssal:R>/gi, '<abyssal reveal>')
+    .replace(/<\/celestial:R>/gi, '</celestial>')
+    .replace(/<\/abyssal:R>/gi, '</abyssal>');
+}
+
+export function preparePostMarkdown(markdown: string): string {
+  return replaceFictionalLangTagTokens(
+    normalizeThinkingTagFormatting(replaceLoreImageTokens(markdown)),
+  );
+}

--- a/lib/tts/contract.ts
+++ b/lib/tts/contract.ts
@@ -1,4 +1,4 @@
-export const TTS_CACHE_VERSION = '3';
+export const TTS_CACHE_VERSION = '1-4';
 /**
  * All TTS document and manifest offsets use JavaScript UTF-16 code units: the
  * same unit used by String#length, String#slice, and DOM Text/Range offsets.

--- a/lib/tts/contract.ts
+++ b/lib/tts/contract.ts
@@ -1,0 +1,60 @@
+export const TTS_CACHE_VERSION = '2';
+export const TTS_CONTENT_HASH_PATTERN = /^[a-f0-9]{64}$/;
+
+export type TtsState = 'not_generated' | 'generating' | 'ready';
+
+export interface TtsTimedStatement {
+  start: number;
+  end: number;
+  paragraph: number;
+  chunk: number;
+  start_ms: number;
+  end_ms: number;
+}
+
+export interface TtsManifestChunk {
+  index: number;
+  start: number;
+  end: number;
+  generated: boolean;
+  start_ms?: number;
+  end_ms?: number;
+}
+
+export interface TtsManifest {
+  cache_version: string;
+  content_hash: string;
+  text_length: number;
+  paragraph_gap_ms: number;
+  duration_ms: number;
+  chunks: TtsManifestChunk[];
+  statements: TtsTimedStatement[];
+}
+
+export interface TtsStatusPayload {
+  status: TtsState;
+  generated_chunks: number;
+  total_chunks: number;
+  playable: boolean;
+  cache_version: string;
+  content_hash: string;
+  manifest?: TtsManifest;
+}
+
+export interface TtsHighlightRange {
+  start: number;
+  end: number;
+  precision: 'statement' | 'chunk';
+}
+
+export function isValidTtsIdentity(contentHash: string | null, cacheVersion: string | null) {
+  return cacheVersion === TTS_CACHE_VERSION && TTS_CONTENT_HASH_PATTERN.test(contentHash ?? '');
+}
+
+export function ttsIdentityQuery(contentHash: string): string {
+  const params = new URLSearchParams({
+    content_hash: contentHash,
+    cache_version: TTS_CACHE_VERSION,
+  });
+  return params.toString();
+}

--- a/lib/tts/contract.ts
+++ b/lib/tts/contract.ts
@@ -52,6 +52,8 @@ export interface TtsHighlightRange {
   start: number;
   end: number;
   precision: 'statement' | 'chunk';
+  /** Duration used for the visual handoff into and out of this range. */
+  handoff_ms: number;
 }
 
 export function isValidTtsIdentity(contentHash: string | null, cacheVersion: string | null) {

--- a/lib/tts/contract.ts
+++ b/lib/tts/contract.ts
@@ -1,4 +1,10 @@
-export const TTS_CACHE_VERSION = '2';
+export const TTS_CACHE_VERSION = '3';
+/**
+ * All TTS document and manifest offsets use JavaScript UTF-16 code units: the
+ * same unit used by String#length, String#slice, and DOM Text/Range offsets.
+ */
+export const TTS_OFFSET_UNIT = 'utf16_code_units' as const;
+export type TtsOffsetUnit = typeof TTS_OFFSET_UNIT;
 export const TTS_CONTENT_HASH_PATTERN = /^[a-f0-9]{64}$/;
 
 export type TtsState = 'not_generated' | 'generating' | 'ready';
@@ -24,6 +30,7 @@ export interface TtsManifestChunk {
 export interface TtsManifest {
   cache_version: string;
   content_hash: string;
+  offset_unit: TtsOffsetUnit;
   text_length: number;
   paragraph_gap_ms: number;
   duration_ms: number;

--- a/lib/tts/highlight.test.ts
+++ b/lib/tts/highlight.test.ts
@@ -112,6 +112,7 @@ describe('TTS DOM highlights', () => {
     );
     const layerone = document.paragraphs.find((paragraph) => paragraph.kind === 'layerone');
     if (!layerone) throw new Error('Expected Layer One paragraph');
+    expect(document.text).not.toContain('*');
 
     applyTtsHighlight(root, document, {
       start: layerone.start,
@@ -129,6 +130,21 @@ describe('TTS DOM highlights', () => {
     clearTtsHighlights(root);
     expect(block?.className).toBe('');
     expect(block?.textContent).toBe('*signal* — now\n');
+  });
+
+  test('ignores visible prose asterisks while retaining highlight alignment', () => {
+    const document = deriveSpeechDocument('Before \\*signal\\* after.');
+    const { root } = createRoot('<p>Before *signal* after.</p>');
+    const original = root.innerHTML;
+
+    applyTtsHighlight(root, document, rangeFor(document.text, 'signal'));
+
+    expect(document.text).toBe('Before signal after.');
+    expect(root.querySelector('.tts-highlight')?.textContent).toBe('signal');
+    expect(root.textContent).toBe('Before *signal* after.');
+
+    clearTtsHighlights(root);
+    expect(root.innerHTML).toBe(original);
   });
 
   test('lets multiple Layer One blocks linger and cancels a linger on reactivation', () => {

--- a/lib/tts/highlight.test.ts
+++ b/lib/tts/highlight.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from 'bun:test';
+import { Window } from 'happy-dom';
+import { applyTtsHighlight, clearTtsHighlights } from './highlight';
+import { deriveSpeechDocument } from './speechDocument';
+
+function createRoot(html: string, reducedMotion = false) {
+  const window = new Window();
+  window.SyntaxError = SyntaxError;
+  window.matchMedia = (() => ({ matches: reducedMotion })) as typeof window.matchMedia;
+  const root = window.document.createElement('div');
+  root.innerHTML = html;
+  window.document.body.append(root);
+  return { root: root as unknown as HTMLElement, window };
+}
+
+function rangeFor(text: string, selected: string, precision: 'statement' | 'chunk' = 'statement') {
+  const start = text.indexOf(selected);
+  if (start < 0) throw new Error(`Missing selection: ${selected}`);
+  return {
+    start,
+    end: start + selected.length,
+    precision,
+    handoff_ms: precision === 'statement' ? 250 : 350,
+  } as const;
+}
+
+describe('TTS DOM highlights', () => {
+  test('wraps the selected text and clears without changing content', () => {
+    const document = deriveSpeechDocument('Hello world.');
+    const { root } = createRoot('<p>Hello world.</p>');
+    const original = root.innerHTML;
+
+    applyTtsHighlight(root, document, rangeFor(document.text, 'world'));
+
+    expect(root.querySelector('.tts-highlight')?.textContent).toBe('world');
+    expect(root.textContent).toBe('Hello world.');
+
+    clearTtsHighlights(root);
+    expect(root.innerHTML).toBe(original);
+  });
+
+  test('segments partial styled boundaries instead of restructuring markup', () => {
+    const document = deriveSpeechDocument('Hello **bold words** ending.');
+    const { root } = createRoot('<p>Hello <strong>bold words</strong> ending.</p>');
+    const original = root.innerHTML;
+
+    applyTtsHighlight(root, document, rangeFor(document.text, 'ld words end'));
+
+    expect(root.querySelectorAll('.tts-highlight')).toHaveLength(2);
+    expect(root.querySelector('strong')?.textContent).toBe('bold words');
+    expect(root.textContent).toBe(document.text);
+
+    clearTtsHighlights(root);
+    expect(root.innerHTML).toBe(original);
+  });
+
+  test('supports UTF-16 offsets, collapsed whitespace, and repeated reapplication', () => {
+    const document = deriveSpeechDocument('Launch 🚀   now.\n\nSecond line.');
+    const { root } = createRoot('<p>Launch 🚀   now.</p><p>Second line.</p>');
+    const originalText = root.textContent;
+    const selected = '🚀 now.';
+
+    applyTtsHighlight(root, document, rangeFor(document.text, selected));
+    expect(root.querySelectorAll('.tts-highlight')).toHaveLength(1);
+    expect(root.querySelector('.tts-highlight')?.textContent).toBe('🚀   now.');
+
+    clearTtsHighlights(root);
+    applyTtsHighlight(root, document, rangeFor(document.text, 'Second', 'chunk'));
+    expect(root.querySelectorAll('.tts-highlight')).toHaveLength(1);
+    expect(root.querySelector('.tts-highlight--chunk')?.textContent).toBe('Second');
+    expect(root.textContent).toBe(originalText);
+  });
+
+  test('keeps an outgoing paragraph mounted through a gap before the next block', () => {
+    const document = deriveSpeechDocument('First paragraph.\n\nSecond paragraph.');
+    const { root } = createRoot('<p>First paragraph.</p><p>Second paragraph.</p>');
+
+    applyTtsHighlight(root, document, rangeFor(document.text, 'First paragraph.'));
+    clearTtsHighlights(root, { normal: 'transition', layerone: 'linger' });
+
+    const outgoing = root.querySelector('.tts-highlight--exiting');
+    expect(outgoing?.textContent).toBe('First paragraph.');
+
+    applyTtsHighlight(root, document, rangeFor(document.text, 'Second paragraph.'));
+
+    expect(outgoing?.isConnected).toBe(true);
+    expect(root.querySelector('.tts-highlight--entering')?.textContent).toBe('Second paragraph.');
+    expect(root.textContent).toBe('First paragraph.Second paragraph.');
+  });
+
+  test('keeps inline code excluded while highlighting spoken text around it', () => {
+    const document = deriveSpeechDocument('Before `hidden()` after.');
+    const { root } = createRoot('<p>Before <code>hidden()</code> after.</p>');
+
+    applyTtsHighlight(root, document, {
+      start: 0,
+      end: document.text.length,
+      precision: 'chunk',
+      handoff_ms: 350,
+    });
+
+    expect(root.querySelector('code .tts-highlight')).toBeNull();
+    expect(root.querySelector('code')?.textContent).toBe('hidden()');
+    expect(root.querySelectorAll('.tts-highlight')).toHaveLength(2);
+  });
+
+  test('activates whole Layer One blocks and preserves literal code text', () => {
+    const markdown = 'Before.\n\n```layerone\n*signal* — now\n```\n\nAfter.';
+    const document = deriveSpeechDocument(markdown);
+    const { root } = createRoot(
+      '<p>Before.</p><pre><code class="language-layerone">*signal* — now\n</code></pre><p>After.</p>',
+    );
+    const layerone = document.paragraphs.find((paragraph) => paragraph.kind === 'layerone');
+    if (!layerone) throw new Error('Expected Layer One paragraph');
+
+    applyTtsHighlight(root, document, {
+      start: layerone.start,
+      end: layerone.end,
+      precision: 'statement',
+      handoff_ms: 250,
+    });
+
+    const block = root.querySelector('pre');
+    expect(block?.classList.contains('tts-layerone-active')).toBe(true);
+    expect(block?.classList.contains('tts-layerone-entering')).toBe(true);
+    expect(block?.textContent).toBe('*signal* — now\n');
+    expect(block?.querySelector('.tts-highlight')).toBeNull();
+
+    clearTtsHighlights(root);
+    expect(block?.className).toBe('');
+    expect(block?.textContent).toBe('*signal* — now\n');
+  });
+
+  test('lets multiple Layer One blocks linger and cancels a linger on reactivation', () => {
+    const markdown = '```layerone\none\n```\n\nMiddle.\n\n```layerone\ntwo\n```';
+    const document = deriveSpeechDocument(markdown);
+    const { root } = createRoot(
+      '<pre><code class="language-layerone">one\n</code></pre><p>Middle.</p><pre><code class="language-layerone">two\n</code></pre>',
+    );
+    const [first, , second] = document.paragraphs;
+    if (!first || !second) throw new Error('Expected Layer One paragraphs');
+
+    applyTtsHighlight(root, document, {
+      start: first.start,
+      end: first.end,
+      precision: 'statement',
+      handoff_ms: 250,
+    });
+    applyTtsHighlight(root, document, {
+      start: second.start,
+      end: second.end,
+      precision: 'statement',
+      handoff_ms: 250,
+    });
+
+    const blocks = root.querySelectorAll('pre');
+    expect(blocks[0]?.classList.contains('tts-layerone-lingering')).toBe(true);
+    expect(blocks[1]?.classList.contains('tts-layerone-active')).toBe(true);
+
+    applyTtsHighlight(root, document, {
+      start: first.start,
+      end: first.end,
+      precision: 'statement',
+      handoff_ms: 250,
+    });
+    expect(blocks[0]?.classList.contains('tts-layerone-active')).toBe(true);
+    expect(blocks[0]?.classList.contains('tts-layerone-lingering')).toBe(false);
+    expect(blocks[1]?.classList.contains('tts-layerone-lingering')).toBe(true);
+  });
+
+  test('uses immediate static Layer One state when reduced motion is requested', () => {
+    const markdown = '```layerone\nsignal\n```';
+    const document = deriveSpeechDocument(markdown);
+    const { root } = createRoot('<pre><code class="language-layerone">signal\n</code></pre>', true);
+    const layerone = document.paragraphs[0];
+    if (!layerone) throw new Error('Expected Layer One paragraph');
+
+    applyTtsHighlight(root, document, {
+      start: layerone.start,
+      end: layerone.end,
+      precision: 'statement',
+      handoff_ms: 250,
+    });
+
+    const block = root.querySelector('pre');
+    expect(block?.classList.contains('tts-layerone-active')).toBe(true);
+    expect(block?.classList.contains('tts-layerone-entering')).toBe(false);
+
+    clearTtsHighlights(root, { layerone: 'linger' });
+    expect(block?.className).toBe('');
+  });
+});

--- a/lib/tts/highlight.ts
+++ b/lib/tts/highlight.ts
@@ -1,0 +1,350 @@
+import type { TtsHighlightRange } from '@/lib/tts/contract';
+import type { SpeechDocument } from '@/lib/tts/speechDocument';
+
+const HIGHLIGHT_CLASS = 'tts-highlight';
+const LAYERONE_ACTIVE_CLASS = 'tts-layerone-active';
+const LAYERONE_ENTERING_CLASS = 'tts-layerone-entering';
+const LAYERONE_LINGERING_CLASS = 'tts-layerone-lingering';
+const LAYERONE_ENTRY_MS = 600;
+const LAYERONE_LINGER_MS = 10_000;
+
+interface DomPoint {
+  node: Text;
+  offset: number;
+}
+
+interface NormalizedDomText {
+  layeroneBlock: HTMLElement | null;
+  text: string;
+  textNodes: Text[];
+  starts: DomPoint[];
+  ends: DomPoint[];
+}
+
+interface ClearOptions {
+  normal?: 'immediate' | 'transition';
+  layerone?: 'immediate' | 'linger';
+}
+
+const elementTimers = new WeakMap<HTMLElement, number>();
+
+function clearElementTimer(element: HTMLElement) {
+  const timer = elementTimers.get(element);
+  if (timer === undefined) return;
+  const view = element.ownerDocument.defaultView;
+  if (view) view.clearTimeout(timer);
+  else globalThis.clearTimeout(timer);
+  elementTimers.delete(element);
+}
+
+function setElementTimer(element: HTMLElement, callback: () => void, delay: number) {
+  clearElementTimer(element);
+  const view = element.ownerDocument.defaultView;
+  const callbackWithCleanup = () => {
+    elementTimers.delete(element);
+    callback();
+  };
+  const timer = view
+    ? view.setTimeout(callbackWithCleanup, delay)
+    : (globalThis.setTimeout(callbackWithCleanup, delay) as unknown as number);
+  elementTimers.set(element, timer);
+}
+
+function prefersReducedMotion(element: Element): boolean {
+  return Boolean(
+    element.ownerDocument.defaultView?.matchMedia?.('(prefers-reduced-motion: reduce)').matches,
+  );
+}
+
+function normalizeSpeechDomText(
+  root: Element,
+  excludedDescendants: Set<Element>,
+  layeroneBlock: HTMLElement | null = null,
+): NormalizedDomText {
+  const textNodes: Text[] = [];
+  const showText = root.ownerDocument.defaultView?.NodeFilter.SHOW_TEXT ?? 4;
+  const walker = root.ownerDocument.createTreeWalker(root, showText);
+  let current = walker.nextNode();
+  while (current) {
+    const textNode = current as Text;
+    const parent = textNode.parentElement;
+    if (
+      parent &&
+      !Array.from(excludedDescendants).some(
+        (excluded) => excluded === parent || excluded.contains(parent),
+      )
+    ) {
+      textNodes.push(textNode);
+    }
+    current = walker.nextNode();
+  }
+
+  let text = '';
+  const starts: DomPoint[] = [];
+  const ends: DomPoint[] = [];
+  let pendingWhitespaceStart: DomPoint | null = null;
+  let pendingWhitespaceEnd: DomPoint | null = null;
+
+  for (const node of textNodes) {
+    for (let offset = 0; offset < node.data.length; offset += 1) {
+      const character = node.data[offset] ?? '';
+      if (/\s/u.test(character)) {
+        pendingWhitespaceStart ??= { node, offset };
+        pendingWhitespaceEnd = { node, offset: offset + 1 };
+        continue;
+      }
+
+      if (pendingWhitespaceStart && pendingWhitespaceEnd && text.length > 0) {
+        text += ' ';
+        starts.push(pendingWhitespaceStart);
+        ends.push(pendingWhitespaceEnd);
+      }
+      pendingWhitespaceStart = null;
+      pendingWhitespaceEnd = null;
+      text += character;
+      starts.push({ node, offset });
+      ends.push({ node, offset: offset + 1 });
+    }
+  }
+
+  return { layeroneBlock, text, textNodes, starts, ends };
+}
+
+function getSpeechDomCandidates(root: HTMLElement): NormalizedDomText[] {
+  const candidates: NormalizedDomText[] = [];
+  for (const element of root.querySelectorAll('p, li, pre')) {
+    if (element.closest('h1, h2, h3, h4, h5, h6, table')) continue;
+
+    if (element.tagName === 'PRE') {
+      const layerone = element.querySelector('code.language-layerone');
+      if (!layerone) continue;
+      candidates.push(normalizeSpeechDomText(layerone, new Set(), element as HTMLElement));
+      continue;
+    }
+
+    if (
+      element.tagName === 'LI' &&
+      Array.from(element.children).some((child) => child.tagName === 'P')
+    ) {
+      continue;
+    }
+
+    const excluded = new Set<Element>();
+    for (const descendant of element.querySelectorAll('code, pre, img, table, ul, ol')) {
+      if (
+        element.tagName === 'LI' &&
+        (descendant.tagName === 'UL' || descendant.tagName === 'OL')
+      ) {
+        excluded.add(descendant);
+      } else if (descendant.tagName === 'CODE' || descendant.tagName === 'PRE') {
+        excluded.add(descendant);
+      }
+    }
+    candidates.push(normalizeSpeechDomText(element, excluded));
+  }
+  return candidates.filter((candidate) => candidate.text.length > 0);
+}
+
+function buildParagraphMappings(
+  root: HTMLElement,
+  speechDocument: SpeechDocument,
+): Array<NormalizedDomText | null> {
+  const candidates = getSpeechDomCandidates(root);
+  const mappings: Array<NormalizedDomText | null> = [];
+  let candidateIndex = 0;
+
+  for (const paragraph of speechDocument.paragraphs) {
+    const expected = speechDocument.text.slice(paragraph.start, paragraph.end);
+    let mapping: NormalizedDomText | null = null;
+    while (candidateIndex < candidates.length) {
+      const candidate = candidates[candidateIndex] ?? null;
+      candidateIndex += 1;
+      if (candidate?.text === expected) {
+        mapping = candidate;
+        break;
+      }
+    }
+    mappings.push(mapping);
+  }
+  return mappings;
+}
+
+function unwrapHighlights(spans: HTMLElement[]) {
+  const parents = new Set<Node>();
+  for (const span of [...spans].reverse()) {
+    if (!span.isConnected) continue;
+    clearElementTimer(span);
+    const parent = span.parentNode;
+    if (!parent) continue;
+    parents.add(parent);
+    span.replaceWith(...Array.from(span.childNodes));
+  }
+  for (const parent of parents) parent.normalize();
+}
+
+function resetLayeroneBlock(block: HTMLElement) {
+  clearElementTimer(block);
+  block.classList.remove(LAYERONE_ACTIVE_CLASS, LAYERONE_ENTERING_CLASS, LAYERONE_LINGERING_CLASS);
+}
+
+function lingerLayeroneBlock(block: HTMLElement) {
+  if (!block.classList.contains(LAYERONE_ACTIVE_CLASS)) return;
+  if (prefersReducedMotion(block)) {
+    resetLayeroneBlock(block);
+    return;
+  }
+  clearElementTimer(block);
+  block.classList.remove(LAYERONE_ACTIVE_CLASS, LAYERONE_ENTERING_CLASS);
+  block.classList.add(LAYERONE_LINGERING_CLASS);
+  setElementTimer(block, () => resetLayeroneBlock(block), LAYERONE_LINGER_MS);
+}
+
+function activateLayeroneBlock(block: HTMLElement) {
+  if (block.classList.contains(LAYERONE_ACTIVE_CLASS)) return;
+  clearElementTimer(block);
+  block.classList.remove(LAYERONE_LINGERING_CLASS);
+  block.classList.add(LAYERONE_ACTIVE_CLASS);
+  if (prefersReducedMotion(block)) return;
+  block.classList.add(LAYERONE_ENTERING_CLASS);
+  setElementTimer(block, () => block.classList.remove(LAYERONE_ENTERING_CLASS), LAYERONE_ENTRY_MS);
+}
+
+function rangesOverlap(start: number, end: number, range: TtsHighlightRange): boolean {
+  return start < range.end && end > range.start;
+}
+
+function transitionHighlightsOut(root: HTMLElement) {
+  const highlights = Array.from(root.querySelectorAll<HTMLElement>(`.${HIGHLIGHT_CLASS}`)).filter(
+    (span) => !span.classList.contains('tts-highlight--exiting'),
+  );
+
+  for (const span of highlights) {
+    span.classList.remove('tts-highlight--entering', 'tts-highlight--active');
+    span.classList.add('tts-highlight--exiting');
+    const duration = prefersReducedMotion(span)
+      ? 0
+      : Math.max(0, Number(span.dataset.ttsHandoffMs) || 0);
+    setElementTimer(span, () => unwrapHighlights([span]), duration + 50);
+  }
+}
+
+function transitionOldHighlights(root: HTMLElement, range: TtsHighlightRange) {
+  const active = Array.from(root.querySelectorAll<HTMLElement>(`.${HIGHLIGHT_CLASS}`)).filter(
+    (span) => !span.classList.contains('tts-highlight--exiting'),
+  );
+  const overlapping = active.filter((span) =>
+    rangesOverlap(Number(span.dataset.ttsStart), Number(span.dataset.ttsEnd), range),
+  );
+  unwrapHighlights(overlapping);
+  transitionHighlightsOut(root);
+
+  const exitingOverlaps = Array.from(
+    root.querySelectorAll<HTMLElement>('.tts-highlight--exiting'),
+  ).filter((span) =>
+    rangesOverlap(Number(span.dataset.ttsStart), Number(span.dataset.ttsEnd), range),
+  );
+  unwrapHighlights(exitingOverlaps);
+}
+
+function createTextSegments(
+  mapping: NormalizedDomText,
+  relativeStart: number,
+  relativeEnd: number,
+): Array<{ node: Text; start: number; end: number }> {
+  const start = mapping.starts[relativeStart];
+  const end = mapping.ends[relativeEnd - 1];
+  if (!start || !end) return [];
+
+  const startIndex = mapping.textNodes.indexOf(start.node);
+  const endIndex = mapping.textNodes.indexOf(end.node);
+  if (startIndex < 0 || endIndex < startIndex) return [];
+
+  const segments: Array<{ node: Text; start: number; end: number }> = [];
+  for (let index = startIndex; index <= endIndex; index += 1) {
+    const node = mapping.textNodes[index];
+    if (!node) continue;
+    const segmentStart = index === startIndex ? start.offset : 0;
+    const segmentEnd = index === endIndex ? end.offset : node.data.length;
+    if (segmentEnd > segmentStart) segments.push({ node, start: segmentStart, end: segmentEnd });
+  }
+  return segments;
+}
+
+function wrapSegment(
+  segment: { node: Text; start: number; end: number },
+  activeRange: TtsHighlightRange,
+): HTMLElement | null {
+  if (!segment.node.isConnected) return null;
+  const document = segment.node.ownerDocument;
+  const range = document.createRange();
+  range.setStart(segment.node, segment.start);
+  range.setEnd(segment.node, segment.end);
+
+  const span = document.createElement('span');
+  span.className = `${HIGHLIGHT_CLASS} tts-highlight--${activeRange.precision} tts-highlight--entering`;
+  span.dataset.ttsStart = String(activeRange.start);
+  span.dataset.ttsEnd = String(activeRange.end);
+  span.dataset.ttsHandoffMs = String(activeRange.handoff_ms);
+  const handoffMs = prefersReducedMotion(span) ? 0 : activeRange.handoff_ms;
+  span.style.setProperty('--tts-handoff-ms', `${handoffMs}ms`);
+  range.surroundContents(span);
+  setElementTimer(
+    span,
+    () => {
+      if (!span.isConnected) return;
+      span.classList.remove('tts-highlight--entering');
+      span.classList.add('tts-highlight--active');
+    },
+    handoffMs,
+  );
+  return span;
+}
+
+export function clearTtsHighlights(root: HTMLElement, options: ClearOptions = {}) {
+  delete root.dataset.ttsActiveRange;
+  if (options.normal === 'transition') transitionHighlightsOut(root);
+  else unwrapHighlights(Array.from(root.querySelectorAll<HTMLElement>(`.${HIGHLIGHT_CLASS}`)));
+
+  for (const block of root.querySelectorAll<HTMLElement>(
+    `pre.${LAYERONE_ACTIVE_CLASS}, pre.${LAYERONE_ENTERING_CLASS}, pre.${LAYERONE_LINGERING_CLASS}`,
+  )) {
+    if (options.layerone === 'linger') lingerLayeroneBlock(block);
+    else resetLayeroneBlock(block);
+  }
+}
+
+export function applyTtsHighlight(
+  root: HTMLElement,
+  speechDocument: SpeechDocument,
+  activeRange: TtsHighlightRange,
+) {
+  const rangeKey = `${activeRange.start}:${activeRange.end}:${activeRange.precision}`;
+  if (root.dataset.ttsActiveRange === rangeKey) return;
+
+  transitionOldHighlights(root, activeRange);
+  const mappings = buildParagraphMappings(root, speechDocument);
+  const activeLayeroneBlocks = new Set<HTMLElement>();
+  const segments: Array<{ node: Text; start: number; end: number }> = [];
+
+  speechDocument.paragraphs.forEach((paragraph, index) => {
+    const start = Math.max(activeRange.start, paragraph.start);
+    const end = Math.min(activeRange.end, paragraph.end);
+    const mapping = mappings[index];
+    if (!mapping || end <= start) return;
+
+    if (mapping.layeroneBlock) {
+      activeLayeroneBlocks.add(mapping.layeroneBlock);
+      return;
+    }
+
+    segments.push(...createTextSegments(mapping, start - paragraph.start, end - paragraph.start));
+  });
+
+  for (const block of root.querySelectorAll<HTMLElement>(`pre.${LAYERONE_ACTIVE_CLASS}`)) {
+    if (!activeLayeroneBlocks.has(block)) lingerLayeroneBlock(block);
+  }
+  for (const block of activeLayeroneBlocks) activateLayeroneBlock(block);
+
+  for (const segment of segments.reverse()) wrapSegment(segment, activeRange);
+  root.dataset.ttsActiveRange = rangeKey;
+}

--- a/lib/tts/highlight.ts
+++ b/lib/tts/highlight.ts
@@ -93,6 +93,7 @@ function normalizeSpeechDomText(
         pendingWhitespaceEnd = { node, offset: offset + 1 };
         continue;
       }
+      if (character === '*') continue;
 
       if (pendingWhitespaceStart && pendingWhitespaceEnd && text.length > 0) {
         text += ' ';

--- a/lib/tts/speechDocument.test.ts
+++ b/lib/tts/speechDocument.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { blogRendererTestPost, loreRendererTestPost } from '@/lib/content/test-posts';
+import { TTS_OFFSET_UNIT } from './contract';
 import {
   deriveSpeechDocument,
   hashSpeechDocument,
@@ -62,6 +63,20 @@ ONLINE
       { start: 0, end: 31, kind: 'prose' },
       { start: 32, end: 42, kind: 'prose' },
     ]);
+  });
+
+  test('uses UTF-16 code-unit paragraph offsets for astral Unicode', () => {
+    const document = deriveSpeechDocument('Launch 🚀 now.\n\nSecond 🧡 paragraph.');
+
+    expect(document.offset_unit).toBe(TTS_OFFSET_UNIT);
+    expect(document.text).toBe('Launch 🚀 now. Second 🧡 paragraph.');
+    expect(document.paragraphs).toEqual([
+      { start: 0, end: 14, kind: 'prose' },
+      { start: 15, end: 35, kind: 'prose' },
+    ]);
+    expect(
+      document.paragraphs.map((paragraph) => document.text.slice(paragraph.start, paragraph.end)),
+    ).toEqual(['Launch 🚀 now.', 'Second 🧡 paragraph.']);
   });
 
   test('only removes a disclaimer when it is the opening substantive block', () => {

--- a/lib/tts/speechDocument.test.ts
+++ b/lib/tts/speechDocument.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  deriveSpeechDocument,
+  hashSpeechDocument,
+  serializeSpeechDocumentForHash,
+} from './speechDocument';
+
+describe('deriveSpeechDocument', () => {
+  test('keeps rendered prose while excluding non-spoken structures', () => {
+    const document = deriveSpeechDocument(`
+> **Disclaimer:** Standard opening copy.
+> It spans lines.
+
+# Hidden heading
+
+First **paragraph** with "dialogue", <thinking>a thought</thinking>, <celestial>language</celestial>, and [a link](/x). It drops \`inline()\`.
+
+> A retained quote.
+
+- First list item.
+- Second list item with ![an image](/image.png).
+
+| Hidden | Table |
+| --- | --- |
+| no | speech |
+
+\`\`\`ts
+const hidden = true;
+\`\`\`
+
+\`\`\`layerone
+DIGITAL   SIGNAL
+ONLINE
+\`\`\`
+
+![Hidden image alt](/image.png)
+
+{{speciescard: lore/w-e-a-v-e}}
+`);
+
+    expect(document.text).toBe(
+      'First paragraph with "dialogue", a thought, "language", and a link. It drops . A retained quote. First list item. Second list item with . DIGITAL SIGNAL ONLINE',
+    );
+    expect(
+      document.paragraphs.map((paragraph) => document.text.slice(paragraph.start, paragraph.end)),
+    ).toEqual([
+      'First paragraph with "dialogue", a thought, "language", and a link. It drops .',
+      'A retained quote.',
+      'First list item.',
+      'Second list item with .',
+      'DIGITAL SIGNAL ONLINE',
+    ]);
+    expect(document.paragraphs.at(-1)?.kind).toBe('layerone');
+  });
+
+  test('normalizes all retained whitespace to single ASCII spaces and rendered punctuation', () => {
+    const document = deriveSpeechDocument('One\tline — “quoted.”\ncontinued.\n\nNext\u00a0line.');
+
+    expect(document.text).toBe('One line - "quoted." continued. Next line.');
+    expect(document.paragraphs).toEqual([
+      { start: 0, end: 31, kind: 'prose' },
+      { start: 32, end: 42, kind: 'prose' },
+    ]);
+  });
+
+  test('only removes a disclaimer when it is the opening substantive block', () => {
+    const document = deriveSpeechDocument(
+      'Opening prose.\n\n> **Disclaimer:** This later quote is content.',
+    );
+
+    expect(document.text).toBe('Opening prose. Disclaimer: This later quote is content.');
+  });
+
+  test('produces stable SHA-256 content identities that include paragraph kinds', async () => {
+    const prose = deriveSpeechDocument('Same text.');
+    const layerone = deriveSpeechDocument('```layerone\nSame text.\n```');
+
+    expect(serializeSpeechDocumentForHash(prose)).not.toBe(
+      serializeSpeechDocumentForHash(layerone),
+    );
+    expect(await hashSpeechDocument(prose)).toMatch(/^[a-f0-9]{64}$/);
+    expect(await hashSpeechDocument(prose)).toBe(await hashSpeechDocument(prose));
+  });
+});

--- a/lib/tts/speechDocument.test.ts
+++ b/lib/tts/speechDocument.test.ts
@@ -31,7 +31,7 @@ const hidden = true;
 \`\`\`
 
 \`\`\`layerone
-DIGITAL   SIGNAL
+*DIGITAL*   SIGNAL
 ONLINE
 \`\`\`
 
@@ -52,6 +52,19 @@ ONLINE
       'Second list item with .',
       'DIGITAL SIGNAL ONLINE',
     ]);
+    expect(document.paragraphs.at(-1)?.kind).toBe('layerone');
+  });
+
+  test('removes every asterisk from spoken prose and Layer One text', () => {
+    const document = deriveSpeechDocument(
+      'Prose \\*signal\\* and 2 \\* 3.\n\n```layerone\n*stay* *not yet*\n```',
+    );
+
+    expect(document.text).toBe('Prose signal and 2 3. stay not yet');
+    expect(document.text).not.toContain('*');
+    expect(
+      document.paragraphs.map((paragraph) => document.text.slice(paragraph.start, paragraph.end)),
+    ).toEqual(['Prose signal and 2 3.', 'stay not yet']);
     expect(document.paragraphs.at(-1)?.kind).toBe('layerone');
   });
 
@@ -106,6 +119,7 @@ ONLINE
       expect(document.text).not.toContain('opening fixture disclaimer');
       expect(document.text).not.toContain('Markdown Coverage');
       expect(document.text).not.toContain('THIS ORDINARY CODE MUST NOT BE SPOKEN');
+      expect(document.text).not.toContain('*');
       expect(document.paragraphs.some((paragraph) => paragraph.kind === 'layerone')).toBe(true);
     }
 

--- a/lib/tts/speechDocument.test.ts
+++ b/lib/tts/speechDocument.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { blogRendererTestPost, loreRendererTestPost } from '@/lib/content/test-posts';
 import {
   deriveSpeechDocument,
   hashSpeechDocument,
@@ -80,5 +81,24 @@ ONLINE
     );
     expect(await hashSpeechDocument(prose)).toMatch(/^[a-f0-9]{64}$/);
     expect(await hashSpeechDocument(prose)).toBe(await hashSpeechDocument(prose));
+  });
+
+  test('covers both hidden renderer fixtures with the same prose-first rules', () => {
+    const blog = deriveSpeechDocument(blogRendererTestPost.content);
+    const lore = deriveSpeechDocument(loreRendererTestPost.content);
+
+    for (const document of [blog, lore]) {
+      expect(document.text).not.toContain('opening fixture disclaimer');
+      expect(document.text).not.toContain('Markdown Coverage');
+      expect(document.text).not.toContain('THIS ORDINARY CODE MUST NOT BE SPOKEN');
+      expect(document.paragraphs.some((paragraph) => paragraph.kind === 'layerone')).toBe(true);
+    }
+
+    expect(blog.text).toContain('This blockquote should keep its contrast');
+    expect(blog.text).toContain('short inline thinking');
+    expect(blog.text).toContain('"text"');
+    expect(lore.text).toContain('Dialogue should receive the lore dialogue treatment');
+    expect(lore.text).toContain('inline private-style thought');
+    expect(lore.text).not.toContain('speciescard');
   });
 });

--- a/lib/tts/speechDocument.ts
+++ b/lib/tts/speechDocument.ts
@@ -6,19 +6,23 @@ import { preparePostMarkdown } from '@/lib/markdown/postMarkdown';
 import remarkFictionalLangTags from '@/lib/markdown/remarkFictionalLangTags';
 import remarkThinkingTags from '@/lib/markdown/remarkThinkingTags';
 import { splitMarkdownSpeciesCareTokens } from '@/lib/species-care/tokens';
+import { TTS_OFFSET_UNIT, type TtsOffsetUnit } from '@/lib/tts/contract';
 
-export { TTS_CACHE_VERSION } from '@/lib/tts/contract';
+export { TTS_CACHE_VERSION, TTS_OFFSET_UNIT } from '@/lib/tts/contract';
 
 export type SpeechParagraphKind = 'prose' | 'layerone';
 
 export interface SpeechParagraph {
+  /** UTF-16 code-unit index, matching String#slice and DOM Text offsets. */
   start: number;
+  /** UTF-16 code-unit index, matching String#slice and DOM Text offsets. */
   end: number;
   kind: SpeechParagraphKind;
 }
 
 export interface SpeechDocument {
   text: string;
+  offset_unit: TtsOffsetUnit;
   paragraphs: SpeechParagraph[];
 }
 
@@ -128,7 +132,7 @@ export function deriveSpeechDocument(markdown: string): SpeechDocument {
     paragraphs.push({ start, end: text.length, kind: paragraph.kind });
   }
 
-  return { text, paragraphs };
+  return { text, offset_unit: TTS_OFFSET_UNIT, paragraphs };
 }
 
 export function serializeSpeechDocumentForHash(document: SpeechDocument): string {

--- a/lib/tts/speechDocument.ts
+++ b/lib/tts/speechDocument.ts
@@ -7,7 +7,7 @@ import remarkFictionalLangTags from '@/lib/markdown/remarkFictionalLangTags';
 import remarkThinkingTags from '@/lib/markdown/remarkThinkingTags';
 import { splitMarkdownSpeciesCareTokens } from '@/lib/species-care/tokens';
 
-export const TTS_CACHE_VERSION = '2';
+export { TTS_CACHE_VERSION } from '@/lib/tts/contract';
 
 export type SpeechParagraphKind = 'prose' | 'layerone';
 

--- a/lib/tts/speechDocument.ts
+++ b/lib/tts/speechDocument.ts
@@ -27,15 +27,21 @@ export interface SpeechDocument {
 }
 
 const EXCLUDED_CONTAINER_TYPES = new Set(['heading', 'table', 'tableRow', 'tableCell']);
+const ASTERISK = /\*/g;
 const CURLY_DOUBLE_QUOTES = /[“”]/g;
 const EM_DASH = /—/g;
 
 function normalizeRenderedProse(value: string): string {
-  return value.replace(CURLY_DOUBLE_QUOTES, '"').replace(EM_DASH, '-').replace(/\s+/gu, ' ').trim();
+  return value
+    .replace(ASTERISK, '')
+    .replace(CURLY_DOUBLE_QUOTES, '"')
+    .replace(EM_DASH, '-')
+    .replace(/\s+/gu, ' ')
+    .trim();
 }
 
 function normalizeLayerone(value: string): string {
-  return value.replace(/\s+/gu, ' ').trim();
+  return value.replace(ASTERISK, '').replace(/\s+/gu, ' ').trim();
 }
 
 function isParent(node: Content | Root): node is (Content | Root) & Parent {

--- a/lib/tts/speechDocument.ts
+++ b/lib/tts/speechDocument.ts
@@ -1,0 +1,145 @@
+import type { Content, Parent, Root } from 'mdast';
+import remarkGfm from 'remark-gfm';
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+import { preparePostMarkdown } from '@/lib/markdown/postMarkdown';
+import remarkFictionalLangTags from '@/lib/markdown/remarkFictionalLangTags';
+import remarkThinkingTags from '@/lib/markdown/remarkThinkingTags';
+import { splitMarkdownSpeciesCareTokens } from '@/lib/species-care/tokens';
+
+export const TTS_CACHE_VERSION = '2';
+
+export type SpeechParagraphKind = 'prose' | 'layerone';
+
+export interface SpeechParagraph {
+  start: number;
+  end: number;
+  kind: SpeechParagraphKind;
+}
+
+export interface SpeechDocument {
+  text: string;
+  paragraphs: SpeechParagraph[];
+}
+
+const EXCLUDED_CONTAINER_TYPES = new Set(['heading', 'table', 'tableRow', 'tableCell']);
+const CURLY_DOUBLE_QUOTES = /[“”]/g;
+const EM_DASH = /—/g;
+
+function normalizeRenderedProse(value: string): string {
+  return value.replace(CURLY_DOUBLE_QUOTES, '"').replace(EM_DASH, '-').replace(/\s+/gu, ' ').trim();
+}
+
+function normalizeLayerone(value: string): string {
+  return value.replace(/\s+/gu, ' ').trim();
+}
+
+function isParent(node: Content | Root): node is (Content | Root) & Parent {
+  return Array.isArray((node as Parent).children);
+}
+
+function inlineText(node: Content): string {
+  if (node.type === 'text') return node.value;
+  if (node.type === 'break') return ' ';
+  if (node.type === 'inlineCode' || node.type === 'image' || node.type === 'imageReference') {
+    return '';
+  }
+  if (node.type === 'html') return '';
+  if (!isParent(node)) return '';
+  return node.children.map((child) => inlineText(child as Content)).join('');
+}
+
+function blockText(node: Content): string {
+  if (EXCLUDED_CONTAINER_TYPES.has(node.type)) return '';
+  if (node.type === 'code') return node.lang?.toLowerCase() === 'layerone' ? node.value : '';
+  if (node.type === 'paragraph') return inlineText(node);
+  if (!isParent(node)) return '';
+  return node.children.map((child) => blockText(child as Content)).join(' ');
+}
+
+function isStandardOpeningDisclaimer(node: Content): boolean {
+  if (node.type !== 'blockquote') return false;
+  return /^disclaimer\s*:/i.test(normalizeRenderedProse(blockText(node)));
+}
+
+function collectParagraphs(
+  node: Content,
+  output: Array<{ text: string; kind: SpeechParagraphKind }>,
+) {
+  if (EXCLUDED_CONTAINER_TYPES.has(node.type)) return;
+
+  if (node.type === 'code') {
+    if (node.lang?.toLowerCase() === 'layerone') {
+      const text = normalizeLayerone(node.value);
+      if (text) output.push({ text, kind: 'layerone' });
+    }
+    return;
+  }
+
+  if (node.type === 'paragraph') {
+    const text = normalizeRenderedProse(inlineText(node));
+    if (text) output.push({ text, kind: 'prose' });
+    return;
+  }
+
+  if (!isParent(node)) return;
+  for (const child of node.children) {
+    collectParagraphs(child as Content, output);
+  }
+}
+
+function parseMarkdown(markdown: string): Root {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkThinkingTags)
+    .use(remarkFictionalLangTags);
+  return processor.runSync(processor.parse(markdown)) as Root;
+}
+
+export function deriveSpeechDocument(markdown: string): SpeechDocument {
+  const prepared = preparePostMarkdown(markdown);
+  const collected: Array<{ text: string; kind: SpeechParagraphKind }> = [];
+  let firstSubstantiveNodeSeen = false;
+
+  for (const part of splitMarkdownSpeciesCareTokens(prepared)) {
+    if (part.type !== 'markdown' || !part.content?.trim()) continue;
+    const tree = parseMarkdown(part.content);
+
+    for (const child of tree.children) {
+      const node = child as Content;
+      if (node.type === 'thematicBreak' || node.type === 'definition') continue;
+
+      if (!firstSubstantiveNodeSeen) {
+        firstSubstantiveNodeSeen = true;
+        if (isStandardOpeningDisclaimer(node)) continue;
+      }
+
+      collectParagraphs(node, collected);
+    }
+  }
+
+  let text = '';
+  const paragraphs: SpeechParagraph[] = [];
+  for (const paragraph of collected) {
+    if (text) text += ' ';
+    const start = text.length;
+    text += paragraph.text;
+    paragraphs.push({ start, end: text.length, kind: paragraph.kind });
+  }
+
+  return { text, paragraphs };
+}
+
+export function serializeSpeechDocumentForHash(document: SpeechDocument): string {
+  const paragraphIdentity = document.paragraphs
+    .map((paragraph) => `${paragraph.start}:${paragraph.end}:${paragraph.kind}`)
+    .join('\n');
+  return `tts-document-v1\n${document.text}\n${paragraphIdentity}`;
+}
+
+export async function hashSpeechDocument(document: SpeechDocument): Promise<string> {
+  const bytes = new TextEncoder().encode(serializeSpeechDocumentForHash(document));
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/joy": "^5.0.0-beta.52",
+    "@types/mdast": "^4.0.4",
     "@types/qrcode": "^1.5.6",
     "gray-matter": "4.0.3",
     "highlight.js": "^11.11.1",
@@ -40,6 +41,8 @@
     "rehype-highlight": "^7.0.2",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
-    "sharp": "^0.35.2"
+    "remark-parse": "^11.0.0",
+    "sharp": "^0.35.2",
+    "unified": "^11.0.5"
   }
 }

--- a/tts/server.py
+++ b/tts/server.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse, JSONResponse
 from kokoro import KModel, KPipeline
 from pydantic import BaseModel
+from starlette.datastructures import MutableHeaders
 
 VOICE = "af_heart,af_bella"
 SAMPLE_RATE = 24000
@@ -62,6 +63,19 @@ class GenerateRequest(BaseModel):
     type: str
     content_hash: str
     cache_version: str
+
+
+class RangeFileResponse(FileResponse):
+    async def __call__(self, scope, receive, send):
+        async def send_with_range_headers(message):
+            if message["type"] == "http.response.start" and message["status"] == 416:
+                message = dict(message)
+                headers = MutableHeaders(raw=list(message["headers"]))
+                headers["accept-ranges"] = "bytes"
+                message["headers"] = headers.raw
+            await send(message)
+
+        await super().__call__(scope, receive, send_with_range_headers)
 
 
 def _validate_type_and_slug(type_: str, slug: str) -> None:
@@ -850,7 +864,7 @@ async def audio(
     cache = _cache_path(type_, slug, content_hash)
     if not cache.exists():
         raise HTTPException(status_code=404, detail="Audio not found")
-    return FileResponse(
+    return RangeFileResponse(
         cache,
         media_type="audio/wav",
         filename=f"{slug}-{content_hash[:12]}.wav",

--- a/tts/server.py
+++ b/tts/server.py
@@ -20,7 +20,7 @@ from starlette.datastructures import MutableHeaders
 VOICE = "af_heart,af_bella"
 SAMPLE_RATE = 24000
 TTS_DIR = Path("/tmp/tts")
-CACHE_VERSION = "3"
+CACHE_VERSION = "1-4"
 CACHE_DIRNAME = f"cache-v{CACHE_VERSION}"
 LOCK_TIMEOUT = 300
 MIN_PLAYABLE_CHUNKS = 3
@@ -31,7 +31,7 @@ PARAGRAPH_GAP_SAMPLES = SAMPLE_RATE * PARAGRAPH_GAP_MS // 1000
 VALID_TYPES = {"blog", "lore"}
 CONTENT_HASH_RE = re.compile(r"^[a-f0-9]{64}$")
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$", flags=re.IGNORECASE)
-VERSION_DIR_RE = re.compile(r"^cache-v\d+$")
+VERSION_DIR_RE = re.compile(r"^cache-v\d+(?:-\d+)*$")
 # The public TTS protocol uses JavaScript String/DOM offsets, not Python str
 # indices. UTF-16 code units preserve the frontend's DOM Range mapping.
 OFFSET_UNIT = "utf16_code_units"
@@ -587,20 +587,135 @@ def _synthesize_statement(text: str) -> np.ndarray:
     return np.concatenate(parts)
 
 
+def _fade_audio_fragment(fragment: np.ndarray, fade_ms: int = 4) -> np.ndarray:
+    faded = fragment.astype(np.float32, copy=True)
+    fade_samples = min(
+        int(SAMPLE_RATE * fade_ms / 1000),
+        faded.size // 3,
+    )
+    if fade_samples > 0:
+        ramp = np.linspace(0.0, 1.0, fade_samples, dtype=np.float32)
+        faded[:fade_samples] *= ramp
+        faded[-fade_samples:] *= ramp[::-1]
+    return faded
+
+
+def _insert_audio_fragment(
+    source: np.ndarray, position: int, fragment: np.ndarray
+) -> np.ndarray:
+    if fragment.size == 0:
+        return source
+    return np.concatenate(
+        (source[:position], _fade_audio_fragment(fragment), source[position:])
+    )
+
+
+def _active_audio_bounds(source: np.ndarray) -> tuple[int, int]:
+    if source.size == 0:
+        return 0, 0
+    window_size = min(source.size, max(1, int(SAMPLE_RATE * 0.012)))
+    kernel = np.ones(window_size, dtype=np.float32) / window_size
+    energy = np.convolve(np.abs(source), kernel, mode="same")
+    threshold = max(0.012, float(energy.max()) * 0.08)
+    active = np.flatnonzero(energy > threshold)
+    if active.size == 0:
+        return 0, source.size
+    padding = int(SAMPLE_RATE * 0.025)
+    return (
+        max(0, int(active[0]) - padding),
+        min(source.size, int(active[-1]) + padding),
+    )
+
+
 def _apply_layerone_effect(audio: np.ndarray) -> np.ndarray:
     if audio.size == 0:
         return audio.astype(np.float32, copy=True)
+
     source = audio.astype(np.float32, copy=False)
-    quantized = np.round(source * 96.0) / 96.0
-    sample_positions = np.arange(source.size, dtype=np.float32)
-    modulation = 1.0 + 0.025 * np.sin(
-        2.0 * np.pi * 31.0 * sample_positions / SAMPLE_RATE
+    held = np.repeat(source[::5], 5)[: source.size]
+    crushed = np.round(held * 16.0) / 16.0
+    sample_positions = np.arange(source.size, dtype=np.float32) / SAMPLE_RATE
+    chopped = source * (
+        0.68
+        + 0.32
+        * (np.sin(2.0 * np.pi * 43.0 * sample_positions) >= 0.0)
     )
-    delayed = np.zeros_like(source)
-    delay_samples = max(1, int(SAMPLE_RATE * 0.006))
-    delayed[delay_samples:] = quantized[:-delay_samples]
-    effected = 0.88 * source + 0.09 * quantized * modulation + 0.03 * delayed
-    return np.clip(effected, -1.0, 1.0).astype(np.float32, copy=False)
+    ringed = source * np.sin(2.0 * np.pi * 71.0 * sample_positions)
+
+    echo = np.zeros_like(source)
+    delay_a = int(SAMPLE_RATE * 0.009)
+    delay_b = int(SAMPLE_RATE * 0.021)
+    if source.size > delay_a:
+        echo[delay_a:] += 0.65 * source[:-delay_a]
+    if source.size > delay_b:
+        echo[delay_b:] += 0.35 * source[:-delay_b]
+
+    effected = (
+        0.34 * source
+        + 0.28 * crushed
+        + 0.18 * chopped
+        + 0.12 * echo
+        + 0.08 * ringed
+    )
+
+    active_start, active_end = _active_audio_bounds(effected)
+    active_span = max(1, active_end - active_start)
+    first_position = active_start + int(active_span * 0.34)
+    first_size = min(
+        int(SAMPLE_RATE * 0.055),
+        max(int(SAMPLE_RATE * 0.032), active_span // 7),
+    )
+    first_start = max(active_start, first_position - first_size)
+    effected = _insert_audio_fragment(
+        effected,
+        first_position,
+        effected[first_start:first_position],
+    )
+
+    active_start, active_end = _active_audio_bounds(effected)
+    active_span = max(1, active_end - active_start)
+    second_position = active_start + int(active_span * 0.67)
+    second_size = min(
+        int(SAMPLE_RATE * 0.038),
+        max(int(SAMPLE_RATE * 0.022), active_span // 11),
+    )
+    second_start = max(active_start, second_position - second_size)
+    reversed_fragment = effected[second_start:second_position][::-1]
+    effected = _insert_audio_fragment(effected, second_position, reversed_fragment)
+
+    active_start, active_end = _active_audio_bounds(effected)
+    active_span = max(1, active_end - active_start)
+    envelope = np.ones(effected.size, dtype=np.float32)
+    for fraction, duration_ms, floor in (
+        (0.23, 16, 0.06),
+        (0.51, 22, 0.10),
+        (0.79, 14, 0.04),
+    ):
+        center = active_start + int(active_span * fraction)
+        dip_size = min(
+            active_span,
+            max(1, int(SAMPLE_RATE * duration_ms / 1000)),
+        )
+        dip_start = max(
+            active_start,
+            min(active_end - dip_size, center - dip_size // 2),
+        )
+        dip_end = dip_start + dip_size
+        edge = min(int(SAMPLE_RATE * 0.003), dip_size // 2)
+        envelope[dip_start:dip_end] = floor
+        if edge > 0:
+            envelope[dip_start : dip_start + edge] = np.linspace(
+                1.0, floor, edge, dtype=np.float32
+            )
+            envelope[dip_end - edge : dip_end] = np.linspace(
+                floor, 1.0, edge, dtype=np.float32
+            )
+    effected *= envelope
+
+    peak = float(np.max(np.abs(effected)))
+    if peak > 0.98:
+        effected *= 0.98 / peak
+    return effected.astype(np.float32, copy=False)
 
 
 def _generate_chunks_worker(

--- a/tts/server.py
+++ b/tts/server.py
@@ -184,35 +184,75 @@ def _validate_document(document: SpeechDocument, content_hash: str) -> None:
 
 
 def _version_root() -> Path:
-    return TTS_DIR / CACHE_DIRNAME
+    return _confined_cache_path(TTS_DIR / CACHE_DIRNAME)
+
+
+def _cache_base() -> Path:
+    """Return the canonical cache root used for containment checks."""
+    return TTS_DIR.resolve(strict=False)
+
+
+def _confined_cache_path(path: Path) -> Path:
+    """Resolve a cache path and reject traversal or symlink escapes."""
+    cache_base = _cache_base()
+    candidate = path.resolve(strict=False)
+    try:
+        candidate.relative_to(cache_base)
+    except ValueError as error:
+        raise ValueError("TTS cache path escapes the cache root") from error
+    return candidate
+
+
+def _validate_cache_components(type_: str, slug: str, content_hash: str) -> None:
+    if type_ not in VALID_TYPES:
+        raise ValueError("Invalid TTS cache type")
+    if not SLUG_RE.fullmatch(slug):
+        raise ValueError("Invalid TTS cache slug")
+    if not CONTENT_HASH_RE.fullmatch(content_hash):
+        raise ValueError("Invalid TTS cache content hash")
 
 
 def _slug_root(type_: str, slug: str) -> Path:
-    return _version_root() / type_ / slug
+    if type_ not in VALID_TYPES:
+        raise ValueError("Invalid TTS cache type")
+    if not SLUG_RE.fullmatch(slug):
+        raise ValueError("Invalid TTS cache slug")
+    return _confined_cache_path(_version_root() / type_ / slug)
 
 
 def _cache_root(type_: str, slug: str, content_hash: str) -> Path:
-    return _slug_root(type_, slug) / content_hash
+    _validate_cache_components(type_, slug, content_hash)
+    return _confined_cache_path(_slug_root(type_, slug) / content_hash)
 
 
 def _cache_path(type_: str, slug: str, content_hash: str) -> Path:
-    return _cache_root(type_, slug, content_hash) / "audio.wav"
+    return _confined_cache_path(
+        _cache_root(type_, slug, content_hash) / "audio.wav"
+    )
 
 
 def _chunks_dir(type_: str, slug: str, content_hash: str) -> Path:
-    return _cache_root(type_, slug, content_hash) / "chunks"
+    return _confined_cache_path(_cache_root(type_, slug, content_hash) / "chunks")
 
 
 def _chunk_path(type_: str, slug: str, content_hash: str, index: int) -> Path:
-    return _chunks_dir(type_, slug, content_hash) / f"{index:04d}.wav"
+    if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+        raise ValueError("Invalid TTS chunk index")
+    return _confined_cache_path(
+        _chunks_dir(type_, slug, content_hash) / f"{index:04d}.wav"
+    )
 
 
 def _status_path(type_: str, slug: str, content_hash: str) -> Path:
-    return _cache_root(type_, slug, content_hash) / "status.json"
+    return _confined_cache_path(
+        _cache_root(type_, slug, content_hash) / "status.json"
+    )
 
 
 def _manifest_path(type_: str, slug: str, content_hash: str) -> Path:
-    return _cache_root(type_, slug, content_hash) / "manifest.json"
+    return _confined_cache_path(
+        _cache_root(type_, slug, content_hash) / "manifest.json"
+    )
 
 
 def _slug_lock_key(type_: str, slug: str) -> str:
@@ -257,22 +297,31 @@ def _release_lock(type_: str, slug: str, content_hash: str) -> None:
 
 
 def _safe_remove(path: Path, expected_parent: Path) -> None:
-    if path.parent != expected_parent or (not path.exists() and not path.is_symlink()):
+    confined_parent = _confined_cache_path(expected_parent)
+    lexical_path = path.absolute()
+    if lexical_path.parent.resolve(strict=False) != confined_parent:
         return
-    if path.is_symlink() or path.is_file():
-        path.unlink(missing_ok=True)
+    if not lexical_path.exists() and not lexical_path.is_symlink():
         return
-    if path.is_dir():
-        shutil.rmtree(path)
+    if lexical_path.is_symlink():
+        lexical_path.unlink(missing_ok=True)
+        return
+    confined_path = _confined_cache_path(lexical_path)
+    if confined_path.is_file():
+        confined_path.unlink(missing_ok=True)
+        return
+    if confined_path.is_dir():
+        shutil.rmtree(confined_path)
 
 
 def _cleanup_cache_versions() -> None:
-    TTS_DIR.mkdir(parents=True, exist_ok=True)
-    for child in TTS_DIR.iterdir():
+    cache_base = _cache_base()
+    cache_base.mkdir(parents=True, exist_ok=True)
+    for child in cache_base.iterdir():
         if child.name in VALID_TYPES or (
             VERSION_DIR_RE.fullmatch(child.name) and child.name != CACHE_DIRNAME
         ):
-            _safe_remove(child, TTS_DIR)
+            _safe_remove(child, cache_base)
 
 
 def _delete_stale_hashes(type_: str, slug: str, content_hash: str) -> None:
@@ -293,20 +342,24 @@ def _reset_outputs(type_: str, slug: str, content_hash: str) -> None:
 
 
 def _atomic_json_write(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(f"{path.suffix}.tmp")
+    confined_path = _confined_cache_path(path)
+    confined_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = _confined_cache_path(
+        confined_path.with_suffix(f"{confined_path.suffix}.tmp")
+    )
     temporary.write_text(
         json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
         encoding="utf-8",
     )
-    temporary.replace(path)
+    temporary.replace(confined_path)
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
-    if not path.exists():
+    confined_path = _confined_cache_path(path)
+    if not confined_path.exists():
         return None
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = json.loads(confined_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
     return payload if isinstance(payload, dict) else None

--- a/tts/server.py
+++ b/tts/server.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 VOICE = "af_heart,af_bella"
 SAMPLE_RATE = 24000
 TTS_DIR = Path("/tmp/tts")
-CACHE_VERSION = "2"
+CACHE_VERSION = "3"
 CACHE_DIRNAME = f"cache-v{CACHE_VERSION}"
 LOCK_TIMEOUT = 300
 MIN_PLAYABLE_CHUNKS = 3
@@ -31,6 +31,9 @@ VALID_TYPES = {"blog", "lore"}
 CONTENT_HASH_RE = re.compile(r"^[a-f0-9]{64}$")
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$", flags=re.IGNORECASE)
 VERSION_DIR_RE = re.compile(r"^cache-v\d+$")
+# The public TTS protocol uses JavaScript String/DOM offsets, not Python str
+# indices. UTF-16 code units preserve the frontend's DOM Range mapping.
+OFFSET_UNIT = "utf16_code_units"
 
 active_locks: dict[str, tuple[str, float]] = {}
 generation_status: dict[str, dict[str, Any]] = {}
@@ -49,6 +52,7 @@ class SpeechParagraph(BaseModel):
 
 class SpeechDocument(BaseModel):
     text: str
+    offset_unit: Literal["utf16_code_units"]
     paragraphs: list[SpeechParagraph]
 
 
@@ -91,6 +95,30 @@ def _calculate_document_hash(document: SpeechDocument) -> str:
     return hashlib.sha256(_document_hash_input(document).encode("utf-8")).hexdigest()
 
 
+class Utf16OffsetMap:
+    """Translate validated protocol offsets to Python code-point indices."""
+
+    def __init__(self, text: str):
+        self.codepoint_to_utf16 = [0]
+        utf16_offset = 0
+        for character in text:
+            utf16_offset += 2 if ord(character) > 0xFFFF else 1
+            self.codepoint_to_utf16.append(utf16_offset)
+        self.utf16_to_codepoint = {
+            offset: index for index, offset in enumerate(self.codepoint_to_utf16)
+        }
+
+    @property
+    def utf16_length(self) -> int:
+        return self.codepoint_to_utf16[-1]
+
+    def to_codepoint(self, utf16_offset: int) -> int | None:
+        return self.utf16_to_codepoint.get(utf16_offset)
+
+    def to_utf16(self, codepoint_offset: int) -> int:
+        return self.codepoint_to_utf16[codepoint_offset]
+
+
 def _validate_document(document: SpeechDocument, content_hash: str) -> None:
     text = document.text
     if not text or text != text.strip() or re.search(r"\s", text.replace(" ", "")):
@@ -102,19 +130,27 @@ def _validate_document(document: SpeechDocument, content_hash: str) -> None:
     if not document.paragraphs:
         raise HTTPException(status_code=400, detail="No readable text to synthesize")
 
+    offsets = Utf16OffsetMap(text)
     expected_start = 0
     for index, paragraph in enumerate(document.paragraphs):
         if paragraph.start != expected_start or paragraph.end <= paragraph.start:
             raise HTTPException(status_code=400, detail="Invalid paragraph offsets")
-        if index > 0 and text[paragraph.start - 1] != " ":
+        start = offsets.to_codepoint(paragraph.start)
+        end = offsets.to_codepoint(paragraph.end)
+        if start is None or end is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Paragraph offsets must align to UTF-16 code-point boundaries",
+            )
+        if index > 0 and text[start - 1] != " ":
             raise HTTPException(
                 status_code=400, detail="Paragraphs must be separated by one space"
             )
-        if paragraph.end > len(text):
+        if paragraph.end > offsets.utf16_length:
             raise HTTPException(
                 status_code=400, detail="Paragraph offset exceeds text length"
             )
-        paragraph_text = text[paragraph.start : paragraph.end]
+        paragraph_text = text[start:end]
         if paragraph_text != paragraph_text.strip():
             raise HTTPException(
                 status_code=400, detail="Paragraph text is not canonical"
@@ -123,7 +159,7 @@ def _validate_document(document: SpeechDocument, content_hash: str) -> None:
             1 if index < len(document.paragraphs) - 1 else 0
         )
 
-    if document.paragraphs[-1].end != len(text):
+    if document.paragraphs[-1].end != offsets.utf16_length:
         raise HTTPException(
             status_code=400, detail="Paragraph offsets do not cover speech text"
         )
@@ -432,8 +468,13 @@ def _split_long_range(text: str, start: int, end: int) -> list[tuple[int, int]]:
 
 def _statement_ranges(document: SpeechDocument) -> list[dict[str, Any]]:
     statements: list[dict[str, Any]] = []
+    offsets = Utf16OffsetMap(document.text)
     for paragraph_index, paragraph in enumerate(document.paragraphs):
-        paragraph_text = document.text[paragraph.start : paragraph.end]
+        paragraph_start = offsets.to_codepoint(paragraph.start)
+        paragraph_end = offsets.to_codepoint(paragraph.end)
+        if paragraph_start is None or paragraph_end is None:
+            raise ValueError("Validated document offsets must align to code-point boundaries")
+        paragraph_text = document.text[paragraph_start:paragraph_end]
         relative_start = 0
         boundaries = list(re.finditer(r"[.!?](?:[\"')\]]*)\s+", paragraph_text))
         relative_ranges: list[tuple[int, int]] = []
@@ -444,8 +485,8 @@ def _statement_ranges(document: SpeechDocument) -> list[dict[str, Any]]:
         relative_ranges.append((relative_start, len(paragraph_text)))
 
         for relative_range in relative_ranges:
-            start = paragraph.start + relative_range[0]
-            end = paragraph.start + relative_range[1]
+            start = paragraph_start + relative_range[0]
+            end = paragraph_start + relative_range[1]
             while start < end and document.text[start] == " ":
                 start += 1
             while end > start and document.text[end - 1] == " ":
@@ -496,18 +537,20 @@ def _chunk_plans(statements: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def _initial_manifest(
     document: SpeechDocument, content_hash: str, plans: list[dict[str, Any]]
 ) -> dict[str, Any]:
+    offsets = Utf16OffsetMap(document.text)
     return {
         "cache_version": CACHE_VERSION,
         "content_hash": content_hash,
-        "text_length": len(document.text),
+        "offset_unit": OFFSET_UNIT,
+        "text_length": offsets.utf16_length,
         "paragraphs": [paragraph.model_dump() for paragraph in document.paragraphs],
         "paragraph_gap_ms": PARAGRAPH_GAP_MS,
         "duration_ms": 0,
         "chunks": [
             {
                 "index": plan["index"],
-                "start": plan["start"],
-                "end": plan["end"],
+                "start": offsets.to_utf16(plan["start"]),
+                "end": offsets.to_utf16(plan["end"]),
                 "generated": False,
             }
             for plan in plans
@@ -554,6 +597,7 @@ def _generate_chunks_worker(
     plans: list[dict[str, Any]],
 ) -> None:
     status_key = _status_key(type_, slug, content_hash)
+    offsets = Utf16OffsetMap(document.text)
     try:
         manifest = _initial_manifest(document, content_hash, plans)
         _atomic_json_write(_manifest_path(type_, slug, content_hash), manifest)
@@ -598,8 +642,8 @@ def _generate_chunks_worker(
                 global_sample += statement_audio.size
                 generated_statements.append(
                     {
-                        "start": statement["start"],
-                        "end": statement["end"],
+                        "start": offsets.to_utf16(statement["start"]),
+                        "end": offsets.to_utf16(statement["end"]),
                         "paragraph": paragraph_index,
                         "chunk": plan["index"],
                         "start_ms": round(start_sample * 1000 / SAMPLE_RATE, 3),

--- a/tts/server.py
+++ b/tts/server.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import re
 import shutil
@@ -6,7 +7,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import soundfile as sf
@@ -18,20 +19,20 @@ from pydantic import BaseModel
 VOICE = "af_heart,af_bella"
 SAMPLE_RATE = 24000
 TTS_DIR = Path("/tmp/tts")
+CACHE_VERSION = "2"
+CACHE_DIRNAME = f"cache-v{CACHE_VERSION}"
 LOCK_TIMEOUT = 300
 MIN_PLAYABLE_CHUNKS = 3
 TARGET_CHUNK_CHARS = 640
 MAX_CHUNK_CHARS = 960
+PARAGRAPH_GAP_MS = 500
+PARAGRAPH_GAP_SAMPLES = SAMPLE_RATE * PARAGRAPH_GAP_MS // 1000
 VALID_TYPES = {"blog", "lore"}
+CONTENT_HASH_RE = re.compile(r"^[a-f0-9]{64}$")
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$", flags=re.IGNORECASE)
+VERSION_DIR_RE = re.compile(r"^cache-v\d+$")
 
-STANDARD_DISCLAIMER_RE = re.compile(
-    r"\A\s*(?:>\s*)?(?:\*\*|__)?Disclaimer:(?:\*\*|__)?[^\n]*\n(?:\s*>\s*.*\n?)*\s*",
-    flags=re.IGNORECASE,
-)
-MARKDOWN_HEADING_RE = re.compile(r"^\s*#{1,6}\s+")
-HORIZONTAL_RULE_RE = re.compile(r"^\s*(?:---+|\*\*\*+|___+)\s*$")
-
-active_locks: dict[str, float] = {}
+active_locks: dict[str, tuple[str, float]] = {}
 generation_status: dict[str, dict[str, Any]] = {}
 state_lock = threading.Lock()
 model: KModel | None = None
@@ -40,265 +41,320 @@ voice_pack = None
 executor = ThreadPoolExecutor(max_workers=1)
 
 
-def _safe_segment(value: str) -> str:
-    return value.replace("/", "_").replace("..", "_").strip() or "unknown"
+class SpeechParagraph(BaseModel):
+    start: int
+    end: int
+    kind: Literal["prose", "layerone"]
 
 
-def _cache_path(type_: str, slug: str) -> Path:
-    return TTS_DIR / _safe_segment(type_) / f"{_safe_segment(slug)}.wav"
+class SpeechDocument(BaseModel):
+    text: str
+    paragraphs: list[SpeechParagraph]
 
 
-def _chunks_dir(type_: str, slug: str) -> Path:
-    return TTS_DIR / _safe_segment(type_) / "_chunks" / _safe_segment(slug)
+class GenerateRequest(BaseModel):
+    document: SpeechDocument
+    slug: str
+    type: str
+    content_hash: str
+    cache_version: str
 
 
-def _chunk_path(type_: str, slug: str, index: int) -> Path:
-    return _chunks_dir(type_, slug) / f"{index:04d}.wav"
+def _validate_type_and_slug(type_: str, slug: str) -> None:
+    if type_ not in VALID_TYPES:
+        raise HTTPException(
+            status_code=400, detail='Invalid type, expected "blog" or "lore"'
+        )
+    if not SLUG_RE.fullmatch(slug):
+        raise HTTPException(status_code=400, detail="Invalid slug")
 
 
-def _status_path(type_: str, slug: str) -> Path:
-    return _chunks_dir(type_, slug) / "status.json"
+def _validate_identity(content_hash: str, cache_version: str) -> None:
+    if cache_version != CACHE_VERSION:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Unsupported TTS cache version; expected {CACHE_VERSION}",
+        )
+    if not CONTENT_HASH_RE.fullmatch(content_hash):
+        raise HTTPException(status_code=400, detail="Invalid content hash")
 
 
-def _lock_key(type_: str, slug: str) -> str:
+def _document_hash_input(document: SpeechDocument) -> str:
+    paragraph_identity = "\n".join(
+        f"{paragraph.start}:{paragraph.end}:{paragraph.kind}"
+        for paragraph in document.paragraphs
+    )
+    return f"tts-document-v1\n{document.text}\n{paragraph_identity}"
+
+
+def _calculate_document_hash(document: SpeechDocument) -> str:
+    return hashlib.sha256(_document_hash_input(document).encode("utf-8")).hexdigest()
+
+
+def _validate_document(document: SpeechDocument, content_hash: str) -> None:
+    text = document.text
+    if not text or text != text.strip() or re.search(r"\s", text.replace(" ", "")):
+        raise HTTPException(status_code=400, detail="Speech text is not canonical")
+    if "  " in text:
+        raise HTTPException(
+            status_code=400, detail="Speech text contains repeated spaces"
+        )
+    if not document.paragraphs:
+        raise HTTPException(status_code=400, detail="No readable text to synthesize")
+
+    expected_start = 0
+    for index, paragraph in enumerate(document.paragraphs):
+        if paragraph.start != expected_start or paragraph.end <= paragraph.start:
+            raise HTTPException(status_code=400, detail="Invalid paragraph offsets")
+        if index > 0 and text[paragraph.start - 1] != " ":
+            raise HTTPException(
+                status_code=400, detail="Paragraphs must be separated by one space"
+            )
+        if paragraph.end > len(text):
+            raise HTTPException(
+                status_code=400, detail="Paragraph offset exceeds text length"
+            )
+        paragraph_text = text[paragraph.start : paragraph.end]
+        if paragraph_text != paragraph_text.strip():
+            raise HTTPException(
+                status_code=400, detail="Paragraph text is not canonical"
+            )
+        expected_start = paragraph.end + (
+            1 if index < len(document.paragraphs) - 1 else 0
+        )
+
+    if document.paragraphs[-1].end != len(text):
+        raise HTTPException(
+            status_code=400, detail="Paragraph offsets do not cover speech text"
+        )
+    if _calculate_document_hash(document) != content_hash:
+        raise HTTPException(
+            status_code=409, detail="Content hash does not match speech document"
+        )
+
+
+def _version_root() -> Path:
+    return TTS_DIR / CACHE_DIRNAME
+
+
+def _slug_root(type_: str, slug: str) -> Path:
+    return _version_root() / type_ / slug
+
+
+def _cache_root(type_: str, slug: str, content_hash: str) -> Path:
+    return _slug_root(type_, slug) / content_hash
+
+
+def _cache_path(type_: str, slug: str, content_hash: str) -> Path:
+    return _cache_root(type_, slug, content_hash) / "audio.wav"
+
+
+def _chunks_dir(type_: str, slug: str, content_hash: str) -> Path:
+    return _cache_root(type_, slug, content_hash) / "chunks"
+
+
+def _chunk_path(type_: str, slug: str, content_hash: str, index: int) -> Path:
+    return _chunks_dir(type_, slug, content_hash) / f"{index:04d}.wav"
+
+
+def _status_path(type_: str, slug: str, content_hash: str) -> Path:
+    return _cache_root(type_, slug, content_hash) / "status.json"
+
+
+def _manifest_path(type_: str, slug: str, content_hash: str) -> Path:
+    return _cache_root(type_, slug, content_hash) / "manifest.json"
+
+
+def _slug_lock_key(type_: str, slug: str) -> str:
     return f"{type_}:{slug}"
 
 
-def _is_locked(type_: str, slug: str) -> bool:
-    key = _lock_key(type_, slug)
+def _status_key(type_: str, slug: str, content_hash: str) -> str:
+    return f"{type_}:{slug}:{content_hash}"
+
+
+def _is_locked(type_: str, slug: str, content_hash: str) -> bool:
+    key = _slug_lock_key(type_, slug)
     now = time.time()
     with state_lock:
-        locked_at = active_locks.get(key)
-        if locked_at is None:
+        active = active_locks.get(key)
+        if active is None:
             return False
+        active_hash, locked_at = active
         if now - locked_at > LOCK_TIMEOUT:
             active_locks.pop(key, None)
             return False
-        return True
+        return active_hash == content_hash
 
 
-def _acquire_lock(type_: str, slug: str) -> bool:
-    key = _lock_key(type_, slug)
+def _acquire_lock(type_: str, slug: str, content_hash: str) -> bool:
+    key = _slug_lock_key(type_, slug)
     now = time.time()
     with state_lock:
-        locked_at = active_locks.get(key)
-        if locked_at is not None and now - locked_at <= LOCK_TIMEOUT:
+        active = active_locks.get(key)
+        if active is not None and now - active[1] <= LOCK_TIMEOUT:
             return False
-        active_locks[key] = now
+        active_locks[key] = (content_hash, now)
         return True
 
 
-def _release_lock(type_: str, slug: str):
+def _release_lock(type_: str, slug: str, content_hash: str) -> None:
+    key = _slug_lock_key(type_, slug)
     with state_lock:
-        active_locks.pop(_lock_key(type_, slug), None)
+        active = active_locks.get(key)
+        if active is not None and active[0] == content_hash:
+            active_locks.pop(key, None)
 
 
-def _strip_standard_disclaimer(text: str) -> str:
-    return STANDARD_DISCLAIMER_RE.sub("", text, count=1)
+def _safe_remove(path: Path, expected_parent: Path) -> None:
+    if path.parent != expected_parent or (not path.exists() and not path.is_symlink()):
+        return
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+        return
+    if path.is_dir():
+        shutil.rmtree(path)
 
 
-def _clean_text(text: str) -> str:
-    text = text.replace("\r\n", "\n")
-    text = _strip_standard_disclaimer(text)
-    text = re.sub(r"\{\{[^}]*\}\}", "", text)
-    text = re.sub(r"!\[([^\]]*)\]\([^)]*\)", r"\1", text)
-    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
-    text = re.sub(r"\*{1,3}([^*]+)\*{1,3}", r"\1", text)
-    text = re.sub(r"_{1,3}([^_]+)_{1,3}", r"\1", text)
-    text = re.sub(r"```layerone\n?([\s\S]*?)```", r"\1", text)
-    text = re.sub(r"```[\s\S]*?```", "", text)
-    text = re.sub(r"`([^`]+)`", r"\1", text)
-    text = re.sub(r"<[^>]+>", "", text)
-
-    cleaned_lines: list[str] = []
-    for raw_line in text.splitlines():
-        if MARKDOWN_HEADING_RE.match(raw_line) or HORIZONTAL_RULE_RE.match(raw_line):
-            continue
-
-        line = re.sub(r"^>\s+", "", raw_line)
-        line = re.sub(r"^\s*[-*+]\s+", "", line)
-        line = re.sub(r"^\s*\d+\.\s+", "", line)
-        line = line.strip()
-
-        if not line:
-            if cleaned_lines and cleaned_lines[-1] != "":
-                cleaned_lines.append("")
-            continue
-
-        cleaned_lines.append(line)
-
-    cleaned = "\n".join(cleaned_lines)
-    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
-    return cleaned.strip()
+def _cleanup_cache_versions() -> None:
+    TTS_DIR.mkdir(parents=True, exist_ok=True)
+    for child in TTS_DIR.iterdir():
+        if child.name in VALID_TYPES or (
+            VERSION_DIR_RE.fullmatch(child.name) and child.name != CACHE_DIRNAME
+        ):
+            _safe_remove(child, TTS_DIR)
 
 
-def _split_long_sentence(sentence: str, limit: int) -> list[str]:
-    words = sentence.split()
-    if not words:
-        return []
-
-    parts: list[str] = []
-    current: list[str] = []
-    current_len = 0
-
-    for word in words:
-        word_len = len(word)
-        if not current:
-            if word_len <= limit:
-                current = [word]
-                current_len = word_len
-            else:
-                for i in range(0, word_len, limit):
-                    parts.append(word[i : i + limit])
-            continue
-
-        projected_len = current_len + 1 + word_len
-        if projected_len <= limit:
-            current.append(word)
-            current_len = projected_len
-            continue
-
-        parts.append(" ".join(current))
-        if word_len <= limit:
-            current = [word]
-            current_len = word_len
-        else:
-            current = []
-            current_len = 0
-            for i in range(0, word_len, limit):
-                parts.append(word[i : i + limit])
-
-    if current:
-        parts.append(" ".join(current))
-    return parts
+def _delete_stale_hashes(type_: str, slug: str, content_hash: str) -> None:
+    slug_root = _slug_root(type_, slug)
+    if not slug_root.is_dir():
+        return
+    for child in slug_root.iterdir():
+        if child.name != content_hash and CONTENT_HASH_RE.fullmatch(child.name):
+            _safe_remove(child, slug_root)
 
 
-def _statement_chunks(paragraph: str) -> list[str]:
-    sentence_candidates = [
-        s.strip() for s in re.split(r"(?<=[.!?])\s+", paragraph) if s.strip()
-    ]
-    if not sentence_candidates:
-        sentence_candidates = [paragraph]
-
-    chunks: list[str] = []
-    for sentence in sentence_candidates:
-        if len(sentence) > MAX_CHUNK_CHARS:
-            chunks.extend(_split_long_sentence(sentence, MAX_CHUNK_CHARS))
-        else:
-            chunks.append(sentence)
-
-    return [chunk for chunk in chunks if chunk]
+def _reset_outputs(type_: str, slug: str, content_hash: str) -> None:
+    cache_root = _cache_root(type_, slug, content_hash)
+    if cache_root.exists():
+        _safe_remove(cache_root, cache_root.parent)
+    with state_lock:
+        generation_status.pop(_status_key(type_, slug, content_hash), None)
 
 
-def _text_chunks(cleaned: str) -> list[str]:
-    paragraphs = [p.strip() for p in re.split(r"\n{2,}", cleaned) if p.strip()]
-    if not paragraphs:
-        return []
-
-    chunks: list[str] = []
-
-    for paragraph in paragraphs:
-        chunks.extend(_statement_chunks(paragraph))
-
-    return [chunk for chunk in chunks if chunk]
+def _atomic_json_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(f"{path.suffix}.tmp")
+    temporary.write_text(
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    temporary.replace(path)
 
 
-def _default_status() -> dict[str, Any]:
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _default_status(content_hash: str) -> dict[str, Any]:
     return {
         "status": "not_generated",
         "generated_chunks": 0,
         "total_chunks": 0,
         "playable": False,
+        "cache_version": CACHE_VERSION,
+        "content_hash": content_hash,
     }
 
 
-def _normalize_status(payload: dict[str, Any]) -> dict[str, Any]:
+def _normalize_status(payload: dict[str, Any], content_hash: str) -> dict[str, Any]:
     status = payload.get("status", "not_generated")
     if status not in {"not_generated", "generating", "ready"}:
         status = "not_generated"
 
     total_chunks = max(0, int(payload.get("total_chunks", 0) or 0))
     generated_chunks = max(0, int(payload.get("generated_chunks", 0) or 0))
-    if total_chunks > 0:
-        generated_chunks = min(generated_chunks, total_chunks)
-    else:
-        generated_chunks = 0
-
+    generated_chunks = min(generated_chunks, total_chunks) if total_chunks else 0
     playable = bool(payload.get("playable", False))
     if status == "ready":
+        generated_chunks = total_chunks
         playable = True
-        if total_chunks > 0:
-            generated_chunks = total_chunks
 
     normalized: dict[str, Any] = {
         "status": status,
         "generated_chunks": generated_chunks,
         "total_chunks": total_chunks,
         "playable": playable,
+        "cache_version": CACHE_VERSION,
+        "content_hash": content_hash,
     }
-
     error = payload.get("error")
     if isinstance(error, str) and error:
         normalized["error"] = error
-
     return normalized
 
 
-def _write_status(type_: str, slug: str, payload: dict[str, Any]) -> dict[str, Any]:
-    normalized = _normalize_status(payload)
-    key = _lock_key(type_, slug)
-    path = _status_path(type_, slug)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_suffix(".tmp")
-    tmp_path.write_text(json.dumps(normalized), encoding="utf-8")
-    tmp_path.replace(path)
+def _write_status(
+    type_: str, slug: str, content_hash: str, payload: dict[str, Any]
+) -> dict[str, Any]:
+    normalized = _normalize_status(payload, content_hash)
+    _atomic_json_write(_status_path(type_, slug, content_hash), normalized)
     with state_lock:
-        generation_status[key] = normalized
+        generation_status[_status_key(type_, slug, content_hash)] = normalized
     return normalized
 
 
-def _read_status(type_: str, slug: str) -> dict[str, Any] | None:
-    key = _lock_key(type_, slug)
+def _read_status(type_: str, slug: str, content_hash: str) -> dict[str, Any] | None:
+    key = _status_key(type_, slug, content_hash)
     with state_lock:
         cached = generation_status.get(key)
     if cached is not None:
         return dict(cached)
 
-    path = _status_path(type_, slug)
-    if not path.exists():
+    payload = _read_json(_status_path(type_, slug, content_hash))
+    if payload is None:
         return None
-
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return None
-
-    if not isinstance(payload, dict):
-        return None
-    normalized = _normalize_status(payload)
+    normalized = _normalize_status(payload, content_hash)
     with state_lock:
         generation_status[key] = normalized
-    return dict(normalized)
+    return normalized
 
 
-def _chunk_file_count(type_: str, slug: str) -> int:
-    chunk_dir = _chunks_dir(type_, slug)
+def _with_manifest(
+    type_: str, slug: str, content_hash: str, status: dict[str, Any]
+) -> dict[str, Any]:
+    result = dict(status)
+    manifest = _read_json(_manifest_path(type_, slug, content_hash))
+    if manifest is not None:
+        result["manifest"] = manifest
+    return result
+
+
+def _chunk_file_count(type_: str, slug: str, content_hash: str) -> int:
+    chunk_dir = _chunks_dir(type_, slug, content_hash)
     if not chunk_dir.exists():
         return 0
     return sum(1 for _ in chunk_dir.glob("*.wav"))
 
 
-def _current_status(type_: str, slug: str) -> dict[str, Any]:
-    status = _read_status(type_, slug)
-    cache_exists = _cache_path(type_, slug).exists()
-    locked = _is_locked(type_, slug)
+def _current_status(type_: str, slug: str, content_hash: str) -> dict[str, Any]:
+    status = _read_status(type_, slug, content_hash)
+    cache_exists = _cache_path(type_, slug, content_hash).exists()
+    locked = _is_locked(type_, slug, content_hash)
 
     if status is None:
         if cache_exists:
-            total = _chunk_file_count(type_, slug)
-            return _write_status(
+            total = _chunk_file_count(type_, slug, content_hash)
+            status = _write_status(
                 type_,
                 slug,
+                content_hash,
                 {
                     "status": "ready",
                     "generated_chunks": total,
@@ -306,20 +362,28 @@ def _current_status(type_: str, slug: str) -> dict[str, Any]:
                     "playable": True,
                 },
             )
+            return _with_manifest(type_, slug, content_hash, status)
         if locked:
-            return {
-                "status": "generating",
-                "generated_chunks": 0,
-                "total_chunks": 0,
-                "playable": False,
-            }
-        return _default_status()
+            return _with_manifest(
+                type_,
+                slug,
+                content_hash,
+                {
+                    **_default_status(content_hash),
+                    "status": "generating",
+                },
+            )
+        return _default_status(content_hash)
 
-    if cache_exists:
-        total = status.get("total_chunks", 0) or _chunk_file_count(type_, slug)
-        return _write_status(
+    if cache_exists and status["status"] != "ready":
+        total = int(
+            status.get("total_chunks", 0)
+            or _chunk_file_count(type_, slug, content_hash)
+        )
+        status = _write_status(
             type_,
             slug,
+            content_hash,
             {
                 **status,
                 "status": "ready",
@@ -328,32 +392,131 @@ def _current_status(type_: str, slug: str) -> dict[str, Any]:
                 "playable": True,
             },
         )
-
-    if locked:
+    elif locked:
         generated = int(status.get("generated_chunks", 0) or 0)
-        return _normalize_status(
+        status = _normalize_status(
             {
                 **status,
                 "status": "generating",
                 "playable": generated >= MIN_PLAYABLE_CHUNKS,
+            },
+            content_hash,
+        )
+    elif status["status"] == "ready" and not cache_exists:
+        status = _default_status(content_hash)
+
+    return _with_manifest(type_, slug, content_hash, status)
+
+
+def _split_long_range(text: str, start: int, end: int) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    while cursor < end:
+        proposed_end = min(cursor + MAX_CHUNK_CHARS, end)
+        if proposed_end < end:
+            boundary = text.rfind(" ", cursor, proposed_end + 1)
+            if boundary > cursor:
+                proposed_end = boundary
+        while cursor < proposed_end and text[cursor] == " ":
+            cursor += 1
+        while proposed_end > cursor and text[proposed_end - 1] == " ":
+            proposed_end -= 1
+        if proposed_end <= cursor:
+            proposed_end = min(cursor + MAX_CHUNK_CHARS, end)
+        ranges.append((cursor, proposed_end))
+        cursor = proposed_end
+        while cursor < end and text[cursor] == " ":
+            cursor += 1
+    return ranges
+
+
+def _statement_ranges(document: SpeechDocument) -> list[dict[str, Any]]:
+    statements: list[dict[str, Any]] = []
+    for paragraph_index, paragraph in enumerate(document.paragraphs):
+        paragraph_text = document.text[paragraph.start : paragraph.end]
+        relative_start = 0
+        boundaries = list(re.finditer(r"[.!?](?:[\"')\]]*)\s+", paragraph_text))
+        relative_ranges: list[tuple[int, int]] = []
+        for boundary in boundaries:
+            sentence_end = len(boundary.group(0).rstrip()) + boundary.start()
+            relative_ranges.append((relative_start, sentence_end))
+            relative_start = boundary.end()
+        relative_ranges.append((relative_start, len(paragraph_text)))
+
+        for relative_range in relative_ranges:
+            start = paragraph.start + relative_range[0]
+            end = paragraph.start + relative_range[1]
+            while start < end and document.text[start] == " ":
+                start += 1
+            while end > start and document.text[end - 1] == " ":
+                end -= 1
+            if start >= end:
+                continue
+            for bounded_start, bounded_end in _split_long_range(
+                document.text, start, end
+            ):
+                statements.append(
+                    {
+                        "start": bounded_start,
+                        "end": bounded_end,
+                        "paragraph": paragraph_index,
+                        "kind": paragraph.kind,
+                    }
+                )
+    return statements
+
+
+def _chunk_plans(statements: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    plans: list[dict[str, Any]] = []
+    current: list[dict[str, Any]] = []
+
+    def flush() -> None:
+        if not current:
+            return
+        plans.append(
+            {
+                "index": len(plans),
+                "start": current[0]["start"],
+                "end": current[-1]["end"],
+                "statements": list(current),
             }
         )
+        current.clear()
 
-    if status.get("status") == "ready" and not cache_exists:
-        return _default_status()
-
-    return status
-
-
-def _reset_outputs(type_: str, slug: str):
-    cache = _cache_path(type_, slug)
-    chunks = _chunks_dir(type_, slug)
-    if chunks.exists():
-        shutil.rmtree(chunks, ignore_errors=True)
-    cache.unlink(missing_ok=True)
+    for statement in statements:
+        if current and statement["end"] - current[0]["start"] > MAX_CHUNK_CHARS:
+            flush()
+        current.append(statement)
+        if current[-1]["end"] - current[0]["start"] >= TARGET_CHUNK_CHARS:
+            flush()
+    flush()
+    return plans
 
 
-def _synthesize_chunk(text: str) -> np.ndarray:
+def _initial_manifest(
+    document: SpeechDocument, content_hash: str, plans: list[dict[str, Any]]
+) -> dict[str, Any]:
+    return {
+        "cache_version": CACHE_VERSION,
+        "content_hash": content_hash,
+        "text_length": len(document.text),
+        "paragraphs": [paragraph.model_dump() for paragraph in document.paragraphs],
+        "paragraph_gap_ms": PARAGRAPH_GAP_MS,
+        "duration_ms": 0,
+        "chunks": [
+            {
+                "index": plan["index"],
+                "start": plan["start"],
+                "end": plan["end"],
+                "generated": False,
+            }
+            for plan in plans
+        ],
+        "statements": [],
+    }
+
+
+def _synthesize_statement(text: str) -> np.ndarray:
     if model is None or pipeline is None or voice_pack is None:
         raise RuntimeError("TTS model is not initialized")
 
@@ -361,72 +524,150 @@ def _synthesize_chunk(text: str) -> np.ndarray:
     for _, ps, _ in pipeline(text, voice=VOICE, speed=0.85, split_pattern=r"\n+"):
         ref_s = voice_pack[len(ps) - 1]
         audio = model(ps, ref_s, 1)
-        parts.append(audio.numpy())
-
+        parts.append(audio.numpy().astype(np.float32, copy=False))
     if not parts:
         return np.zeros(int(SAMPLE_RATE * 0.08), dtype=np.float32)
     return np.concatenate(parts)
 
 
-def _generate_chunks_worker(type_: str, slug: str, chunks: list[str]):
-    key = _lock_key(type_, slug)
+def _apply_layerone_effect(audio: np.ndarray) -> np.ndarray:
+    if audio.size == 0:
+        return audio.astype(np.float32, copy=True)
+    source = audio.astype(np.float32, copy=False)
+    quantized = np.round(source * 96.0) / 96.0
+    sample_positions = np.arange(source.size, dtype=np.float32)
+    modulation = 1.0 + 0.025 * np.sin(
+        2.0 * np.pi * 31.0 * sample_positions / SAMPLE_RATE
+    )
+    delayed = np.zeros_like(source)
+    delay_samples = max(1, int(SAMPLE_RATE * 0.006))
+    delayed[delay_samples:] = quantized[:-delay_samples]
+    effected = 0.88 * source + 0.09 * quantized * modulation + 0.03 * delayed
+    return np.clip(effected, -1.0, 1.0).astype(np.float32, copy=False)
+
+
+def _generate_chunks_worker(
+    type_: str,
+    slug: str,
+    content_hash: str,
+    document: SpeechDocument,
+    plans: list[dict[str, Any]],
+) -> None:
+    status_key = _status_key(type_, slug, content_hash)
     try:
-        collected: list[np.ndarray] = []
-        total = len(chunks)
+        manifest = _initial_manifest(document, content_hash, plans)
+        _atomic_json_write(_manifest_path(type_, slug, content_hash), manifest)
         _write_status(
             type_,
             slug,
+            content_hash,
             {
                 "status": "generating",
                 "generated_chunks": 0,
-                "total_chunks": total,
+                "total_chunks": len(plans),
                 "playable": False,
             },
         )
 
-        for index, chunk_text in enumerate(chunks):
-            audio_chunk = _synthesize_chunk(chunk_text)
-            chunk_path = _chunk_path(type_, slug, index)
-            chunk_path.parent.mkdir(parents=True, exist_ok=True)
-            sf.write(str(chunk_path), audio_chunk, SAMPLE_RATE)
-            collected.append(audio_chunk)
+        collected_chunks: list[np.ndarray] = []
+        global_sample = 0
+        previous_paragraph: int | None = None
 
-            generated = index + 1
+        for plan in plans:
+            chunk_parts: list[np.ndarray] = []
+            chunk_start_sample = global_sample
+            generated_statements: list[dict[str, Any]] = []
+
+            for statement in plan["statements"]:
+                paragraph_index = int(statement["paragraph"])
+                if (
+                    previous_paragraph is not None
+                    and paragraph_index != previous_paragraph
+                ):
+                    gap = np.zeros(PARAGRAPH_GAP_SAMPLES, dtype=np.float32)
+                    chunk_parts.append(gap)
+                    global_sample += gap.size
+
+                statement_text = document.text[statement["start"] : statement["end"]]
+                statement_audio = _synthesize_statement(statement_text)
+                if statement["kind"] == "layerone":
+                    statement_audio = _apply_layerone_effect(statement_audio)
+
+                start_sample = global_sample
+                chunk_parts.append(statement_audio)
+                global_sample += statement_audio.size
+                generated_statements.append(
+                    {
+                        "start": statement["start"],
+                        "end": statement["end"],
+                        "paragraph": paragraph_index,
+                        "chunk": plan["index"],
+                        "start_ms": round(start_sample * 1000 / SAMPLE_RATE, 3),
+                        "end_ms": round(global_sample * 1000 / SAMPLE_RATE, 3),
+                    }
+                )
+                previous_paragraph = paragraph_index
+
+            chunk_audio = (
+                np.concatenate(chunk_parts)
+                if chunk_parts
+                else np.zeros(int(SAMPLE_RATE * 0.08), dtype=np.float32)
+            )
+            chunk_path = _chunk_path(type_, slug, content_hash, plan["index"])
+            chunk_path.parent.mkdir(parents=True, exist_ok=True)
+            sf.write(str(chunk_path), chunk_audio, SAMPLE_RATE)
+            collected_chunks.append(chunk_audio)
+
+            chunk_manifest = manifest["chunks"][plan["index"]]
+            chunk_manifest.update(
+                {
+                    "generated": True,
+                    "start_ms": round(chunk_start_sample * 1000 / SAMPLE_RATE, 3),
+                    "end_ms": round(global_sample * 1000 / SAMPLE_RATE, 3),
+                }
+            )
+            manifest["statements"].extend(generated_statements)
+            manifest["duration_ms"] = round(global_sample * 1000 / SAMPLE_RATE, 3)
+            _atomic_json_write(_manifest_path(type_, slug, content_hash), manifest)
+
+            generated = plan["index"] + 1
             _write_status(
                 type_,
                 slug,
+                content_hash,
                 {
                     "status": "generating",
                     "generated_chunks": generated,
-                    "total_chunks": total,
+                    "total_chunks": len(plans),
                     "playable": generated >= MIN_PLAYABLE_CHUNKS,
                 },
             )
 
         full_audio = (
-            np.concatenate(collected)
-            if collected
+            np.concatenate(collected_chunks)
+            if collected_chunks
             else np.zeros(int(SAMPLE_RATE * 0.08), dtype=np.float32)
         )
-        cache = _cache_path(type_, slug)
+        cache = _cache_path(type_, slug, content_hash)
         cache.parent.mkdir(parents=True, exist_ok=True)
         sf.write(str(cache), full_audio, SAMPLE_RATE)
-
         _write_status(
             type_,
             slug,
+            content_hash,
             {
                 "status": "ready",
-                "generated_chunks": total,
-                "total_chunks": total,
+                "generated_chunks": len(plans),
+                "total_chunks": len(plans),
                 "playable": True,
             },
         )
     except Exception as error:
-        _reset_outputs(type_, slug)
+        _reset_outputs(type_, slug, content_hash)
         _write_status(
             type_,
             slug,
+            content_hash,
             {
                 "status": "not_generated",
                 "generated_chunks": 0,
@@ -436,14 +677,18 @@ def _generate_chunks_worker(type_: str, slug: str, chunks: list[str]):
             },
         )
     finally:
-        _release_lock(type_, slug)
+        _release_lock(type_, slug, content_hash)
         with state_lock:
-            generation_status.pop(key, None)
+            generation_status.pop(status_key, None)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global model, pipeline, voice_pack
+
+    _cleanup_cache_versions()
+    (_version_root() / "blog").mkdir(parents=True, exist_ok=True)
+    (_version_root() / "lore").mkdir(parents=True, exist_ok=True)
 
     model = KModel().to("cpu").eval()
     pipeline = KPipeline(
@@ -452,12 +697,6 @@ async def lifespan(app: FastAPI):
     pipeline.g2p.lexicon.golds["kokoro"] = "kˈOkəɹO"
     voice_pack = pipeline.load_voice(VOICE)
 
-    TTS_DIR.mkdir(parents=True, exist_ok=True)
-    (TTS_DIR / "blog").mkdir(parents=True, exist_ok=True)
-    (TTS_DIR / "lore").mkdir(parents=True, exist_ok=True)
-    (TTS_DIR / "blog" / "_chunks").mkdir(parents=True, exist_ok=True)
-    (TTS_DIR / "lore" / "_chunks").mkdir(parents=True, exist_ok=True)
-
     yield
     executor.shutdown(wait=False)
 
@@ -465,87 +704,111 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 
-class GenerateRequest(BaseModel):
-    text: str
-    slug: str
-    type: str
-
-
 @app.post("/generate")
 async def generate(req: GenerateRequest):
-    if req.type not in VALID_TYPES:
-        raise HTTPException(status_code=400, detail='Invalid type, expected "blog" or "lore"')
+    _validate_type_and_slug(req.type, req.slug)
+    _validate_identity(req.content_hash, req.cache_version)
+    _validate_document(req.document, req.content_hash)
 
-    cleaned = _clean_text(req.text)
-    if not cleaned:
-        raise HTTPException(status_code=400, detail="No readable text to synthesize")
-
-    cache = _cache_path(req.type, req.slug)
+    cache = _cache_path(req.type, req.slug, req.content_hash)
     if cache.exists():
-        return JSONResponse(content=_current_status(req.type, req.slug), status_code=200)
+        return JSONResponse(
+            content=_current_status(req.type, req.slug, req.content_hash),
+            status_code=200,
+        )
 
-    if not _acquire_lock(req.type, req.slug):
-        return JSONResponse(content=_current_status(req.type, req.slug), status_code=409)
+    if not _acquire_lock(req.type, req.slug, req.content_hash):
+        return JSONResponse(
+            content=_current_status(req.type, req.slug, req.content_hash),
+            status_code=409,
+        )
 
-    chunks = _text_chunks(cleaned)
-    if not chunks:
-        _release_lock(req.type, req.slug)
-        raise HTTPException(status_code=400, detail="No valid text chunks to synthesize")
+    statements = _statement_ranges(req.document)
+    plans = _chunk_plans(statements)
+    if not plans:
+        _release_lock(req.type, req.slug, req.content_hash)
+        raise HTTPException(
+            status_code=400, detail="No valid text chunks to synthesize"
+        )
 
-    _reset_outputs(req.type, req.slug)
+    _delete_stale_hashes(req.type, req.slug, req.content_hash)
+    _reset_outputs(req.type, req.slug, req.content_hash)
+    manifest = _initial_manifest(req.document, req.content_hash, plans)
+    _atomic_json_write(_manifest_path(req.type, req.slug, req.content_hash), manifest)
     _write_status(
         req.type,
         req.slug,
+        req.content_hash,
         {
             "status": "generating",
             "generated_chunks": 0,
-            "total_chunks": len(chunks),
+            "total_chunks": len(plans),
             "playable": False,
         },
     )
-    executor.submit(_generate_chunks_worker, req.type, req.slug, chunks)
-
-    return JSONResponse(content=_current_status(req.type, req.slug), status_code=202)
+    executor.submit(
+        _generate_chunks_worker,
+        req.type,
+        req.slug,
+        req.content_hash,
+        req.document,
+        plans,
+    )
+    return JSONResponse(
+        content=_current_status(req.type, req.slug, req.content_hash), status_code=202
+    )
 
 
 @app.get("/status")
-async def status(slug: str, type: str):
-    if type not in VALID_TYPES:
-        raise HTTPException(status_code=400, detail='Invalid type, expected "blog" or "lore"')
-    return _current_status(type, slug)
+async def status(slug: str, type: str, content_hash: str, cache_version: str):
+    _validate_type_and_slug(type, slug)
+    _validate_identity(content_hash, cache_version)
+    return _current_status(type, slug, content_hash)
 
 
 @app.get("/chunk/{type_}/{slug}/{index}")
-async def chunk(type_: str, slug: str, index: int):
-    if type_ not in VALID_TYPES:
-        raise HTTPException(status_code=400, detail='Invalid type, expected "blog" or "lore"')
+async def chunk(
+    type_: str,
+    slug: str,
+    index: int,
+    content_hash: str,
+    cache_version: str,
+):
+    _validate_type_and_slug(type_, slug)
+    _validate_identity(content_hash, cache_version)
     if index < 0:
         raise HTTPException(status_code=400, detail="Chunk index must be >= 0")
 
-    chunk_file = _chunk_path(type_, slug, index)
+    chunk_file = _chunk_path(type_, slug, content_hash, index)
     if chunk_file.exists():
         return FileResponse(
             chunk_file,
             media_type="audio/wav",
-            filename=f"{slug}-{index:04d}.wav",
+            filename=f"{slug}-{content_hash[:12]}-{index:04d}.wav",
+            content_disposition_type="inline",
         )
 
-    current = _current_status(type_, slug)
+    current = _current_status(type_, slug, content_hash)
     if current["status"] == "generating":
         raise HTTPException(status_code=425, detail="Chunk not ready yet")
-
     raise HTTPException(status_code=404, detail="Chunk not found")
 
 
 @app.get("/audio/{type_}/{slug}")
-async def audio(type_: str, slug: str):
-    if type_ not in VALID_TYPES:
-        raise HTTPException(status_code=400, detail='Invalid type, expected "blog" or "lore"')
-    cache = _cache_path(type_, slug)
+async def audio(
+    type_: str,
+    slug: str,
+    content_hash: str,
+    cache_version: str,
+):
+    _validate_type_and_slug(type_, slug)
+    _validate_identity(content_hash, cache_version)
+    cache = _cache_path(type_, slug, content_hash)
     if not cache.exists():
         raise HTTPException(status_code=404, detail="Audio not found")
     return FileResponse(
         cache,
         media_type="audio/wav",
-        filename=f"{slug}.wav",
+        filename=f"{slug}-{content_hash[:12]}.wav",
+        content_disposition_type="inline",
     )

--- a/tts/server.py
+++ b/tts/server.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import re
 import shutil
 import threading
@@ -189,18 +190,31 @@ def _version_root() -> Path:
 
 def _cache_base() -> Path:
     """Return the canonical cache root used for containment checks."""
-    return TTS_DIR.resolve(strict=False)
+    return Path(os.path.realpath(os.fspath(TTS_DIR)))
 
 
 def _confined_cache_path(path: Path) -> Path:
-    """Resolve a cache path and reject traversal or symlink escapes."""
-    cache_base = _cache_base()
-    candidate = path.resolve(strict=False)
-    try:
-        candidate.relative_to(cache_base)
-    except ValueError as error:
-        raise ValueError("TTS cache path escapes the cache root") from error
-    return candidate
+    """Normalize a cache path and reject traversal or symlink escapes."""
+    cache_base = os.path.realpath(os.fspath(TTS_DIR))
+    cache_prefix = f"{cache_base}{os.sep}"
+    candidate = os.path.realpath(os.fspath(path))
+    if not candidate.startswith(cache_prefix):
+        raise ValueError("TTS cache path escapes the cache root")
+    return Path(candidate)
+
+
+def _confined_cache_entry(path: Path) -> Path:
+    """Validate a cache entry path without following its final symlink."""
+    cache_base = os.path.realpath(os.fspath(TTS_DIR))
+    cache_prefix = f"{cache_base}{os.sep}"
+    candidate = os.path.abspath(os.fspath(path))
+    if not candidate.startswith(cache_prefix):
+        raise ValueError("TTS cache path escapes the cache root")
+
+    actual_parent = os.path.realpath(os.path.dirname(candidate))
+    if actual_parent != cache_base and not actual_parent.startswith(cache_prefix):
+        raise ValueError("TTS cache parent escapes the cache root")
+    return Path(candidate)
 
 
 def _validate_cache_components(type_: str, slug: str, content_hash: str) -> None:
@@ -297,16 +311,22 @@ def _release_lock(type_: str, slug: str, content_hash: str) -> None:
 
 
 def _safe_remove(path: Path, expected_parent: Path) -> None:
-    confined_parent = _confined_cache_path(expected_parent)
-    lexical_path = path.absolute()
-    if lexical_path.parent.resolve(strict=False) != confined_parent:
-        return
-    if not lexical_path.exists() and not lexical_path.is_symlink():
+    cache_base = _cache_base()
+    confined_parent = (
+        cache_base
+        if expected_parent == cache_base
+        else _confined_cache_path(expected_parent)
+    )
+    lexical_path = _confined_cache_entry(path)
+    actual_parent = Path(os.path.realpath(os.fspath(lexical_path.parent)))
+    if actual_parent != confined_parent:
         return
     if lexical_path.is_symlink():
         lexical_path.unlink(missing_ok=True)
         return
     confined_path = _confined_cache_path(lexical_path)
+    if not confined_path.exists():
+        return
     if confined_path.is_file():
         confined_path.unlink(missing_ok=True)
         return

--- a/tts/tests/test_server.py
+++ b/tts/tests/test_server.py
@@ -251,6 +251,23 @@ class TtsServerTest(unittest.TestCase):
             self.assertTrue((root / CACHE_DIRNAME).exists())
             self.assertTrue((root / "keep-me").exists())
 
+    def test_startup_unlinks_legacy_symlinks_without_touching_their_targets(self):
+        with (
+            tempfile.TemporaryDirectory() as temporary,
+            tempfile.TemporaryDirectory() as external,
+        ):
+            root = Path(temporary)
+            external_root = Path(external)
+            protected = external_root / "protected.txt"
+            protected.write_text("keep", encoding="utf-8")
+            (root / "cache-v1-3").symlink_to(external_root, target_is_directory=True)
+
+            with patch.object(server, "TTS_DIR", root):
+                _cleanup_cache_versions()
+
+            self.assertFalse((root / "cache-v1-3").exists())
+            self.assertEqual(protected.read_text(encoding="utf-8"), "keep")
+
     def test_new_generation_deletes_stale_hashes_for_the_same_slug_only(self):
         current_hash = "a" * 64
         stale_hash = "b" * 64
@@ -269,6 +286,88 @@ class TtsServerTest(unittest.TestCase):
                 self.assertTrue(current.exists())
                 self.assertFalse(stale.exists())
                 self.assertTrue(other_slug.exists())
+
+    def test_stale_hash_cleanup_unlinks_symlinks_without_removing_targets(self):
+        current_hash = "a" * 64
+        stale_hash = "b" * 64
+        with (
+            tempfile.TemporaryDirectory() as temporary,
+            tempfile.TemporaryDirectory() as external,
+        ):
+            root = Path(temporary)
+            external_root = Path(external)
+            protected = external_root / "protected.txt"
+            protected.write_text("keep", encoding="utf-8")
+
+            with patch.object(server, "TTS_DIR", root):
+                slug_root = server._slug_root("lore", "story")
+                slug_root.mkdir(parents=True)
+                (slug_root / stale_hash).symlink_to(
+                    external_root, target_is_directory=True
+                )
+
+                _delete_stale_hashes("lore", "story", current_hash)
+
+                self.assertFalse((slug_root / stale_hash).exists())
+                self.assertEqual(protected.read_text(encoding="utf-8"), "keep")
+
+    def test_cache_paths_reject_untrusted_components_and_parent_traversal(self):
+        valid_hash = "a" * 64
+        with (
+            tempfile.TemporaryDirectory() as temporary,
+            tempfile.TemporaryDirectory() as external,
+        ):
+            root = Path(temporary)
+            outside = Path(external) / "outside.json"
+            outside.write_text("protected", encoding="utf-8")
+            with patch.object(server, "TTS_DIR", root):
+                for invalid_path in (
+                    lambda: server._cache_path("../../tmp", "post", valid_hash),
+                    lambda: server._cache_path("blog", "../post", valid_hash),
+                    lambda: server._cache_path("blog", "post", "../escape"),
+                    lambda: server._chunk_path("blog", "post", valid_hash, -1),
+                ):
+                    with self.assertRaises(ValueError):
+                        invalid_path()
+
+                with self.assertRaises(ValueError):
+                    server._atomic_json_write(outside, {"changed": True})
+                with self.assertRaises(ValueError):
+                    server._read_json(outside)
+                self.assertEqual(outside.read_text(encoding="utf-8"), "protected")
+
+    def test_cache_paths_reject_symlink_escapes_for_reads_and_writes(self):
+        content_hash = "a" * 64
+        with (
+            tempfile.TemporaryDirectory() as temporary,
+            tempfile.TemporaryDirectory() as external,
+        ):
+            root = Path(temporary)
+            external_root = Path(external)
+            protected = external_root / "status.json"
+            protected.write_text('{"protected":true}', encoding="utf-8")
+            type_root = root / CACHE_DIRNAME / "blog"
+            type_root.mkdir(parents=True)
+            (type_root / "escape").symlink_to(
+                external_root, target_is_directory=True
+            )
+
+            with patch.object(server, "TTS_DIR", root):
+                with self.assertRaises(ValueError):
+                    server._status_path("blog", "escape", content_hash)
+
+                cache_root = server._cache_root("blog", "safe-post", content_hash)
+                cache_root.mkdir(parents=True)
+                status_link = cache_root / "status.json"
+                status_link.symlink_to(protected)
+                with self.assertRaises(ValueError):
+                    server._atomic_json_write(status_link, {"changed": True})
+                with self.assertRaises(ValueError):
+                    server._read_json(status_link)
+
+            self.assertEqual(
+                protected.read_text(encoding="utf-8"), '{"protected":true}'
+            )
 
     def test_cache_version_is_explicit(self):
         self.assertEqual(CACHE_VERSION, "1-4")

--- a/tts/tests/test_server.py
+++ b/tts/tests/test_server.py
@@ -1,68 +1,194 @@
+import json
+import tempfile
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
-from server import _clean_text, _text_chunks
+import numpy as np
+import soundfile as sf
+from fastapi import HTTPException
+
+import server
+from server import (
+    CACHE_DIRNAME,
+    CACHE_VERSION,
+    MAX_CHUNK_CHARS,
+    PARAGRAPH_GAP_MS,
+    SAMPLE_RATE,
+    SpeechDocument,
+    SpeechParagraph,
+    _apply_layerone_effect,
+    _calculate_document_hash,
+    _chunk_plans,
+    _cleanup_cache_versions,
+    _delete_stale_hashes,
+    _generate_chunks_worker,
+    _manifest_path,
+    _statement_ranges,
+    _validate_document,
+)
+
+
+def make_document(text: str, paragraphs: list[tuple[int, int, str]]) -> SpeechDocument:
+    return SpeechDocument(
+        text=text,
+        paragraphs=[
+            SpeechParagraph(start=start, end=end, kind=kind)
+            for start, end, kind in paragraphs
+        ],
+    )
 
 
 class TtsServerTest(unittest.TestCase):
-    def test_clean_text_removes_standard_disclaimer_and_headings(self):
-        source = """
-> **Disclaimer:** This file is fictional roleplay writing created for a
-> tabletop RPG context. It may use real names or familiar details.
+    def test_document_hash_and_offset_validation(self):
+        document = make_document(
+            "First paragraph. DIGITAL SIGNAL",
+            [(0, 16, "prose"), (17, 31, "layerone")],
+        )
+        content_hash = _calculate_document_hash(document)
 
-## Reduced Visibility
+        _validate_document(document, content_hash)
+        self.assertRegex(content_hash, r"^[a-f0-9]{64}$")
 
-One week after the ER, I was dust.
-""".strip()
+        with self.assertRaises(HTTPException) as mismatch:
+            _validate_document(document, "0" * 64)
+        self.assertEqual(mismatch.exception.status_code, 409)
 
-        cleaned = _clean_text(source)
+        invalid = make_document("First paragraph.", [(1, 16, "prose")])
+        with self.assertRaises(HTTPException) as offsets:
+            _validate_document(invalid, _calculate_document_hash(invalid))
+        self.assertEqual(offsets.exception.status_code, 400)
 
-        self.assertNotIn("Disclaimer:", cleaned)
-        self.assertNotIn("Reduced Visibility", cleaned)
-        self.assertEqual(cleaned, "One week after the ER, I was dust.")
+    def test_statement_and_chunk_ranges_are_bounded_and_cover_long_prose(self):
+        text = " ".join(f"word{index}" for index in range(500)) + "."
+        document = make_document(text, [(0, len(text), "prose")])
 
-    def test_clean_text_keeps_inline_emphasis_but_drops_hrules(self):
-        source = """
-Paragraph with **emphasis** and __signal__.
+        statements = _statement_ranges(document)
+        plans = _chunk_plans(statements)
 
----
+        self.assertGreater(len(statements), 1)
+        self.assertGreater(len(plans), 1)
+        self.assertTrue(
+            all(
+                statement["end"] - statement["start"] <= MAX_CHUNK_CHARS
+                for statement in statements
+            )
+        )
+        self.assertTrue(
+            all(plan["end"] - plan["start"] <= MAX_CHUNK_CHARS for plan in plans)
+        )
+        self.assertEqual(statements[0]["start"], 0)
+        self.assertEqual(statements[-1]["end"], len(text))
 
-Another line.
-""".strip()
+    def test_statement_ranges_keep_closing_dialogue_quotes(self):
+        text = 'She said "Hello." Then she left.'
+        document = make_document(text, [(0, len(text), "prose")])
 
-        cleaned = _clean_text(source)
-
-        self.assertEqual(cleaned, "Paragraph with emphasis and signal.\n\nAnother line.")
-
-    def test_text_chunks_emit_one_statement_per_chunk_without_spoken_headings(self):
-        source = """
-## Transit
-
-Her predictive pattern had been reliable before. I took it seriously.
-
-## Arrival
-
-About one hour into the drive, near the 212 intersection, I registered a roadside anomaly.
-""".strip()
-
-        chunks = _text_chunks(_clean_text(source))
+        statements = _statement_ranges(document)
 
         self.assertEqual(
-            chunks,
-            [
-                "Her predictive pattern had been reliable before.",
-                "I took it seriously.",
-                "About one hour into the drive, near the 212 intersection, I registered a roadside anomaly.",
-            ],
+            [text[statement["start"] : statement["end"]] for statement in statements],
+            ['She said "Hello."', "Then she left."],
         )
 
-    def test_text_chunks_split_long_statements_by_word_boundary(self):
-        paragraph = " ".join(["Sentence" for _ in range(200)]) + "."
+    def test_worker_writes_incremental_exact_timings_and_500ms_paragraph_gap(self):
+        document = make_document(
+            "First. Second paragraph.",
+            [(0, 6, "prose"), (7, 24, "layerone")],
+        )
+        content_hash = _calculate_document_hash(document)
+        plans = _chunk_plans(_statement_ranges(document))
 
-        chunks = _text_chunks(_clean_text(paragraph))
+        with tempfile.TemporaryDirectory() as temporary:
+            with (
+                patch.object(server, "TTS_DIR", Path(temporary)),
+                patch.object(
+                    server,
+                    "_synthesize_statement",
+                    return_value=np.full(SAMPLE_RATE // 10, 0.25, dtype=np.float32),
+                ),
+            ):
+                _generate_chunks_worker(
+                    "blog", "test-post", content_hash, document, plans
+                )
 
-        self.assertGreaterEqual(len(chunks), 2)
-        self.assertTrue(all(len(chunk) <= 960 for chunk in chunks))
-        self.assertTrue(all("\n\n" not in chunk for chunk in chunks))
+                manifest = json.loads(
+                    _manifest_path("blog", "test-post", content_hash).read_text(
+                        encoding="utf-8"
+                    )
+                )
+                audio, rate = sf.read(
+                    server._cache_path("blog", "test-post", content_hash),
+                    dtype="float32",
+                )
+
+        self.assertEqual(rate, SAMPLE_RATE)
+        self.assertEqual(manifest["paragraph_gap_ms"], PARAGRAPH_GAP_MS)
+        self.assertEqual(manifest["statements"][0]["start_ms"], 0)
+        self.assertEqual(manifest["statements"][0]["end_ms"], 100)
+        self.assertEqual(manifest["statements"][1]["start_ms"], 600)
+        self.assertEqual(manifest["statements"][1]["end_ms"], 700)
+        self.assertEqual(manifest["duration_ms"], 700)
+        self.assertEqual(len(audio), int(SAMPLE_RATE * 0.7))
+        gap = audio[SAMPLE_RATE // 10 : SAMPLE_RATE // 10 + SAMPLE_RATE // 2]
+        self.assertTrue(np.allclose(gap, 0.0))
+
+    def test_layerone_effect_is_deterministic_subtle_and_non_identity(self):
+        source = np.linspace(-0.8, 0.8, SAMPLE_RATE // 4, dtype=np.float32)
+
+        first = _apply_layerone_effect(source)
+        second = _apply_layerone_effect(source)
+
+        self.assertTrue(np.array_equal(first, second))
+        self.assertFalse(np.array_equal(first, source))
+        self.assertLess(float(np.mean(np.abs(first - source))), 0.03)
+        self.assertLessEqual(float(np.max(np.abs(first))), 1.0)
+
+    def test_startup_removes_only_legacy_and_old_version_directories(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for name in (
+                "blog",
+                "lore",
+                "cache-v1",
+                "cache-v9",
+                CACHE_DIRNAME,
+                "keep-me",
+            ):
+                (root / name).mkdir()
+
+            with patch.object(server, "TTS_DIR", root):
+                _cleanup_cache_versions()
+
+            self.assertFalse((root / "blog").exists())
+            self.assertFalse((root / "lore").exists())
+            self.assertFalse((root / "cache-v1").exists())
+            self.assertFalse((root / "cache-v9").exists())
+            self.assertTrue((root / CACHE_DIRNAME).exists())
+            self.assertTrue((root / "keep-me").exists())
+
+    def test_new_generation_deletes_stale_hashes_for_the_same_slug_only(self):
+        current_hash = "a" * 64
+        stale_hash = "b" * 64
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            with patch.object(server, "TTS_DIR", root):
+                current = server._cache_root("lore", "story", current_hash)
+                stale = server._cache_root("lore", "story", stale_hash)
+                other_slug = server._cache_root("lore", "other-story", stale_hash)
+                current.mkdir(parents=True)
+                stale.mkdir(parents=True)
+                other_slug.mkdir(parents=True)
+
+                _delete_stale_hashes("lore", "story", current_hash)
+
+                self.assertTrue(current.exists())
+                self.assertFalse(stale.exists())
+                self.assertTrue(other_slug.exists())
+
+    def test_cache_version_is_explicit(self):
+        self.assertEqual(CACHE_VERSION, "2")
+        self.assertEqual(CACHE_DIRNAME, "cache-v2")
 
 
 if __name__ == "__main__":

--- a/tts/tests/test_server.py
+++ b/tts/tests/test_server.py
@@ -13,6 +13,7 @@ from server import (
     CACHE_DIRNAME,
     CACHE_VERSION,
     MAX_CHUNK_CHARS,
+    OFFSET_UNIT,
     PARAGRAPH_GAP_MS,
     SAMPLE_RATE,
     SpeechDocument,
@@ -32,6 +33,7 @@ from server import (
 def make_document(text: str, paragraphs: list[tuple[int, int, str]]) -> SpeechDocument:
     return SpeechDocument(
         text=text,
+        offset_unit=OFFSET_UNIT,
         paragraphs=[
             SpeechParagraph(start=start, end=end, kind=kind)
             for start, end, kind in paragraphs
@@ -133,6 +135,51 @@ class TtsServerTest(unittest.TestCase):
         gap = audio[SAMPLE_RATE // 10 : SAMPLE_RATE // 10 + SAMPLE_RATE // 2]
         self.assertTrue(np.allclose(gap, 0.0))
 
+    def test_astral_utf16_offsets_validate_and_round_trip_through_manifest(self):
+        document = make_document(
+            "Launch 🚀 now. Second 🧡 paragraph.",
+            [(0, 14, "prose"), (15, 35, "layerone")],
+        )
+        content_hash = _calculate_document_hash(document)
+        _validate_document(document, content_hash)
+        plans = _chunk_plans(_statement_ranges(document))
+
+        with tempfile.TemporaryDirectory() as temporary:
+            with (
+                patch.object(server, "TTS_DIR", Path(temporary)),
+                patch.object(
+                    server,
+                    "_synthesize_statement",
+                    return_value=np.full(SAMPLE_RATE // 10, 0.25, dtype=np.float32),
+                ),
+            ):
+                _generate_chunks_worker(
+                    "blog", "astral-post", content_hash, document, plans
+                )
+                manifest = json.loads(
+                    _manifest_path("blog", "astral-post", content_hash).read_text(
+                        encoding="utf-8"
+                    )
+                )
+
+        self.assertEqual(manifest["offset_unit"], OFFSET_UNIT)
+        self.assertEqual(manifest["text_length"], 35)
+        self.assertEqual(manifest["paragraphs"], [
+            {"start": 0, "end": 14, "kind": "prose"},
+            {"start": 15, "end": 35, "kind": "layerone"},
+        ])
+        self.assertEqual(
+            [(statement["start"], statement["end"]) for statement in manifest["statements"]],
+            [(0, 14), (15, 35)],
+        )
+
+        split_surrogate_pair = make_document("🚀 text", [(0, 1, "prose")])
+        with self.assertRaises(HTTPException) as invalid_offsets:
+            _validate_document(
+                split_surrogate_pair, _calculate_document_hash(split_surrogate_pair)
+            )
+        self.assertEqual(invalid_offsets.exception.status_code, 400)
+
     def test_layerone_effect_is_deterministic_subtle_and_non_identity(self):
         source = np.linspace(-0.8, 0.8, SAMPLE_RATE // 4, dtype=np.float32)
 
@@ -187,8 +234,8 @@ class TtsServerTest(unittest.TestCase):
                 self.assertTrue(other_slug.exists())
 
     def test_cache_version_is_explicit(self):
-        self.assertEqual(CACHE_VERSION, "2")
-        self.assertEqual(CACHE_DIRNAME, "cache-v2")
+        self.assertEqual(CACHE_VERSION, "3")
+        self.assertEqual(CACHE_DIRNAME, "cache-v3")
 
 
 if __name__ == "__main__":

--- a/tts/tests/test_server.py
+++ b/tts/tests/test_server.py
@@ -101,6 +101,12 @@ class TtsServerTest(unittest.TestCase):
         )
         content_hash = _calculate_document_hash(document)
         plans = _chunk_plans(_statement_ranges(document))
+        synthesized = np.full(SAMPLE_RATE // 10, 0.25, dtype=np.float32)
+        expected_layerone = _apply_layerone_effect(synthesized)
+        expected_end_ms = round(
+            600 + expected_layerone.size * 1000 / SAMPLE_RATE,
+            3,
+        )
 
         with tempfile.TemporaryDirectory() as temporary:
             with (
@@ -108,7 +114,7 @@ class TtsServerTest(unittest.TestCase):
                 patch.object(
                     server,
                     "_synthesize_statement",
-                    return_value=np.full(SAMPLE_RATE // 10, 0.25, dtype=np.float32),
+                    return_value=synthesized,
                 ),
             ):
                 _generate_chunks_worker(
@@ -130,9 +136,12 @@ class TtsServerTest(unittest.TestCase):
         self.assertEqual(manifest["statements"][0]["start_ms"], 0)
         self.assertEqual(manifest["statements"][0]["end_ms"], 100)
         self.assertEqual(manifest["statements"][1]["start_ms"], 600)
-        self.assertEqual(manifest["statements"][1]["end_ms"], 700)
-        self.assertEqual(manifest["duration_ms"], 700)
-        self.assertEqual(len(audio), int(SAMPLE_RATE * 0.7))
+        self.assertEqual(manifest["statements"][1]["end_ms"], expected_end_ms)
+        self.assertEqual(manifest["duration_ms"], expected_end_ms)
+        self.assertEqual(
+            len(audio),
+            SAMPLE_RATE // 10 + SAMPLE_RATE // 2 + expected_layerone.size,
+        )
         gap = audio[SAMPLE_RATE // 10 : SAMPLE_RATE // 10 + SAMPLE_RATE // 2]
         self.assertTrue(np.allclose(gap, 0.0))
 
@@ -181,16 +190,41 @@ class TtsServerTest(unittest.TestCase):
             )
         self.assertEqual(invalid_offsets.exception.status_code, 400)
 
-    def test_layerone_effect_is_deterministic_subtle_and_non_identity(self):
-        source = np.linspace(-0.8, 0.8, SAMPLE_RATE // 4, dtype=np.float32)
+    def test_layerone_effect_is_deterministic_glitchy_and_peak_limited(self):
+        sample_positions = np.arange(SAMPLE_RATE, dtype=np.float32) / SAMPLE_RATE
+        envelope = np.zeros(SAMPLE_RATE, dtype=np.float32)
+        envelope[SAMPLE_RATE // 10 : -SAMPLE_RATE // 10] = np.hanning(
+            SAMPLE_RATE - SAMPLE_RATE // 5
+        )
+        source = (
+            0.65 * np.sin(2.0 * np.pi * 220.0 * sample_positions) * envelope
+        ).astype(np.float32)
+        original = source.copy()
 
         first = _apply_layerone_effect(source)
         second = _apply_layerone_effect(source)
 
         self.assertTrue(np.array_equal(first, second))
-        self.assertFalse(np.array_equal(first, source))
-        self.assertLess(float(np.mean(np.abs(first - source))), 0.03)
-        self.assertLessEqual(float(np.max(np.abs(first))), 1.0)
+        self.assertTrue(np.array_equal(source, original))
+        self.assertGreater(first.size, source.size)
+        self.assertFalse(np.allclose(first[: source.size], source))
+        self.assertEqual(first.dtype, np.float32)
+        self.assertTrue(np.all(np.isfinite(first)))
+        self.assertLessEqual(float(np.max(np.abs(first))), 0.9801)
+
+    def test_layerone_effect_handles_empty_silent_and_tiny_audio(self):
+        for source in (
+            np.array([], dtype=np.float32),
+            np.zeros(1, dtype=np.float32),
+            np.zeros(80, dtype=np.float32),
+            np.full(200, 0.2, dtype=np.float32),
+        ):
+            effected = _apply_layerone_effect(source)
+
+            self.assertEqual(effected.dtype, np.float32)
+            self.assertTrue(np.all(np.isfinite(effected)))
+            if effected.size:
+                self.assertLessEqual(float(np.max(np.abs(effected))), 0.9801)
 
     def test_startup_removes_only_legacy_and_old_version_directories(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -198,7 +232,8 @@ class TtsServerTest(unittest.TestCase):
             for name in (
                 "blog",
                 "lore",
-                "cache-v1",
+                "cache-v3",
+                "cache-v1-3",
                 "cache-v9",
                 CACHE_DIRNAME,
                 "keep-me",
@@ -210,7 +245,8 @@ class TtsServerTest(unittest.TestCase):
 
             self.assertFalse((root / "blog").exists())
             self.assertFalse((root / "lore").exists())
-            self.assertFalse((root / "cache-v1").exists())
+            self.assertFalse((root / "cache-v3").exists())
+            self.assertFalse((root / "cache-v1-3").exists())
             self.assertFalse((root / "cache-v9").exists())
             self.assertTrue((root / CACHE_DIRNAME).exists())
             self.assertTrue((root / "keep-me").exists())
@@ -235,8 +271,8 @@ class TtsServerTest(unittest.TestCase):
                 self.assertTrue(other_slug.exists())
 
     def test_cache_version_is_explicit(self):
-        self.assertEqual(CACHE_VERSION, "3")
-        self.assertEqual(CACHE_DIRNAME, "cache-v3")
+        self.assertEqual(CACHE_VERSION, "1-4")
+        self.assertEqual(CACHE_DIRNAME, "cache-v1-4")
 
     def test_audio_range_responses_include_range_contract_headers(self):
         content_hash = "a" * 64

--- a/tts/tests/test_server.py
+++ b/tts/tests/test_server.py
@@ -317,9 +317,13 @@ class TtsServerTest(unittest.TestCase):
             tempfile.TemporaryDirectory() as temporary,
             tempfile.TemporaryDirectory() as external,
         ):
-            root = Path(temporary)
+            root = Path(temporary) / "tts"
+            root.mkdir()
             outside = Path(external) / "outside.json"
             outside.write_text("protected", encoding="utf-8")
+            prefix_sibling = Path(temporary) / "tts-escape" / "outside.json"
+            prefix_sibling.parent.mkdir()
+            prefix_sibling.write_text("protected", encoding="utf-8")
             with patch.object(server, "TTS_DIR", root):
                 for invalid_path in (
                     lambda: server._cache_path("../../tmp", "post", valid_hash),
@@ -334,7 +338,12 @@ class TtsServerTest(unittest.TestCase):
                     server._atomic_json_write(outside, {"changed": True})
                 with self.assertRaises(ValueError):
                     server._read_json(outside)
+                with self.assertRaises(ValueError):
+                    server._atomic_json_write(prefix_sibling, {"changed": True})
                 self.assertEqual(outside.read_text(encoding="utf-8"), "protected")
+                self.assertEqual(
+                    prefix_sibling.read_text(encoding="utf-8"), "protected"
+                )
 
     def test_cache_paths_reject_symlink_escapes_for_reads_and_writes(self):
         content_hash = "a" * 64

--- a/tts/tests/test_server.py
+++ b/tts/tests/test_server.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import numpy as np
 import soundfile as sf
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
 import server
 from server import (
@@ -236,6 +237,40 @@ class TtsServerTest(unittest.TestCase):
     def test_cache_version_is_explicit(self):
         self.assertEqual(CACHE_VERSION, "3")
         self.assertEqual(CACHE_DIRNAME, "cache-v3")
+
+    def test_audio_range_responses_include_range_contract_headers(self):
+        content_hash = "a" * 64
+
+        with tempfile.TemporaryDirectory() as temporary:
+            with patch.object(server, "TTS_DIR", Path(temporary)):
+                audio_path = server._cache_path("blog", "range-post", content_hash)
+                audio_path.parent.mkdir(parents=True)
+                audio_path.write_bytes(b"0123456789")
+
+                client = TestClient(server.app)
+                request_params = {
+                    "content_hash": content_hash,
+                    "cache_version": CACHE_VERSION,
+                }
+
+                partial = client.get(
+                    "/audio/blog/range-post",
+                    params=request_params,
+                    headers={"Range": "bytes=0-2"},
+                )
+                unsatisfiable = client.get(
+                    "/audio/blog/range-post",
+                    params=request_params,
+                    headers={"Range": "bytes=10-"},
+                )
+
+        self.assertEqual(partial.status_code, 206)
+        self.assertEqual(partial.headers["accept-ranges"], "bytes")
+        self.assertEqual(partial.headers["content-range"], "bytes 0-2/10")
+        self.assertEqual(partial.content, b"012")
+        self.assertEqual(unsatisfiable.status_code, 416)
+        self.assertEqual(unsatisfiable.headers["accept-ranges"], "bytes")
+        self.assertEqual(unsatisfiable.headers["content-range"], "bytes */10")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Extract speech from rendered blog and lore prose first, with 500ms pauses between paragraphs and a subtle fenced `layerone` digital voice.
- Drive sentence highlighting from manifests, falling back to chunks when needed, under a UTF-16 offset contract.
- Use versioned, content-hashed caches with cleanup for old versions, and compliant `206`/`416` Range responses.
- Support password-gated lore and cover the behavior with both blog and lore renderer test fixtures.

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenCode TUI](https://github.com/anomalyco/opencode)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
