### PR TITLE
Overhaul prose-first TTS with resilient timing and range delivery

### DIFF
--- a/components/blog/TtsPlayer.test.tsx
+++ b/components/blog/TtsPlayer.test.tsx
@@ -373,6 +373,100 @@ afterEach(async () => {
 });
 
 describe('TtsPlayer', () => {
+  test('waits for delayed hashing before polling a non-playable generation to ready', async () => {
+    const originalDigest = crypto.subtle.digest;
+    const digestBytes = new Uint8Array(
+      TEST_CONTENT_HASH.match(/.{2}/g)?.map((byte) => Number.parseInt(byte, 16)) ?? [],
+    );
+    let resolveDigest: (() => void) | null = null;
+    let statusRequests = 0;
+
+    crypto.subtle.digest = (() =>
+      new Promise<ArrayBuffer>((resolve) => {
+        resolveDigest = () => resolve(digestBytes.buffer);
+      })) as typeof crypto.subtle.digest;
+
+    try {
+      setFetchMock(async (url) => {
+        if (url.includes('/api/tts/status')) {
+          statusRequests += 1;
+          if (statusRequests === 1) return jsonResponse(payload('not_generated'));
+          if (statusRequests === 2) {
+            return jsonResponse(
+              payload('generating', {
+                generated_chunks: 2,
+                total_chunks: 10,
+                playable: false,
+              }),
+            );
+          }
+          return jsonResponse(
+            payload('ready', { generated_chunks: 10, total_chunks: 10, playable: true }),
+          );
+        }
+
+        if (url.includes('/api/tts/generate?')) {
+          return jsonResponse(
+            payload('generating', {
+              generated_chunks: 1,
+              total_chunks: 10,
+              playable: false,
+            }),
+            202,
+          );
+        }
+
+        throw new Error(`Unexpected fetch: ${url}`);
+      });
+
+      await renderPlayer();
+
+      expect(intervalCallback).toBeNull();
+      expect(statusRequests).toBe(0);
+
+      await act(async () => {
+        resolveDigest?.();
+        await flushEffects();
+      });
+
+      await waitForCondition(() => statusRequests === 1, 'Expected initial hashed status request');
+
+      const listenButton = getVisibleListenButton();
+      if (!(listenButton instanceof testWindow.HTMLElement)) {
+        throw new Error('Expected visible listen button');
+      }
+
+      await act(async () => {
+        listenButton.dispatchEvent(new testWindow.MouseEvent('click', { bubbles: true }));
+        await flushEffects();
+      });
+
+      expect(
+        await waitForElement(getVisibleGeneratingBar, 'Expected generating bar'),
+      ).not.toBeNull();
+
+      await act(async () => {
+        intervalCallback?.();
+        await flushEffects();
+      });
+
+      expect(statusRequests).toBe(2);
+      expect(getVisibleGeneratingBar()).not.toBeNull();
+
+      await act(async () => {
+        intervalCallback?.();
+        await flushEffects();
+      });
+
+      expect(
+        await waitForElement(() => getVisibleReadyButton('Play'), 'Expected ready Play button'),
+      ).not.toBeNull();
+      expect(statusRequests).toBe(3);
+    } finally {
+      crypto.subtle.digest = originalDigest;
+    }
+  });
+
   test('shows the generating bar immediately when another visitor already started generation', async () => {
     setFetchMock(async (url) => {
       if (url.includes('/api/tts/status')) {

--- a/components/blog/TtsPlayer.tsx
+++ b/components/blog/TtsPlayer.tsx
@@ -825,6 +825,11 @@ export function TtsPlayer({
   ]);
 
   useEffect(() => {
+    if (!contentHash) {
+      stopPolling();
+      return;
+    }
+
     let isActive = true;
 
     const syncInitialStatus = async () => {
@@ -837,8 +842,9 @@ export function TtsPlayer({
 
     return () => {
       isActive = false;
+      stopPolling();
     };
-  }, [checkStatus, startPolling]);
+  }, [checkStatus, contentHash, startPolling, stopPolling]);
 
   const gradientBg = useMemo(
     () =>

--- a/tts/server.py
+++ b/tts/server.py
@@ -184,35 +184,75 @@ def _validate_document(document: SpeechDocument, content_hash: str) -> None:
 
 
 def _version_root() -> Path:
-    return TTS_DIR / CACHE_DIRNAME
+    return _confined_cache_path(TTS_DIR / CACHE_DIRNAME)
+
+
+def _cache_base() -> Path:
+    """Return the canonical cache root used for containment checks."""
+    return TTS_DIR.resolve(strict=False)
+
+
+def _confined_cache_path(path: Path) -> Path:
+    """Resolve a cache path and reject traversal or symlink escapes."""
+    cache_base = _cache_base()
+    candidate = path.resolve(strict=False)
+    try:
+        candidate.relative_to(cache_base)
+    except ValueError as error:
+        raise ValueError("TTS cache path escapes the cache root") from error
+    return candidate
+
+
+def _validate_cache_components(type_: str, slug: str, content_hash: str) -> None:
+    if type_ not in VALID_TYPES:
+        raise ValueError("Invalid TTS cache type")
+    if not SLUG_RE.fullmatch(slug):
+        raise ValueError("Invalid TTS cache slug")
+    if not CONTENT_HASH_RE.fullmatch(content_hash):
+        raise ValueError("Invalid TTS cache content hash")
 
 
 def _slug_root(type_: str, slug: str) -> Path:
-    return _version_root() / type_ / slug
+    if type_ not in VALID_TYPES:
+        raise ValueError("Invalid TTS cache type")
+    if not SLUG_RE.fullmatch(slug):
+        raise ValueError("Invalid TTS cache slug")
+    return _confined_cache_path(_version_root() / type_ / slug)
 
 
 def _cache_root(type_: str, slug: str, content_hash: str) -> Path:
-    return _slug_root(type_, slug) / content_hash
+    _validate_cache_components(type_, slug, content_hash)
+    return _confined_cache_path(_slug_root(type_, slug) / content_hash)
 
 
 def _cache_path(type_: str, slug: str, content_hash: str) -> Path:
-    return _cache_root(type_, slug, content_hash) / "audio.wav"
+    return _confined_cache_path(
+        _cache_root(type_, slug, content_hash) / "audio.wav"
+    )
 
 
 def _chunks_dir(type_: str, slug: str, content_hash: str) -> Path:
-    return _cache_root(type_, slug, content_hash) / "chunks"
+    return _confined_cache_path(_cache_root(type_, slug, content_hash) / "chunks")
 
 
 def _chunk_path(type_: str, slug: str, content_hash: str, index: int) -> Path:
-    return _chunks_dir(type_, slug, content_hash) / f"{index:04d}.wav"
+    if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+        raise ValueError("Invalid TTS chunk index")
+    return _confined_cache_path(
+        _chunks_dir(type_, slug, content_hash) / f"{index:04d}.wav"
+    )
 
 
 def _status_path(type_: str, slug: str, content_hash: str) -> Path:
-    return _cache_root(type_, slug, content_hash) / "status.json"
+    return _confined_cache_path(
+        _cache_root(type_, slug, content_hash) / "status.json"
+    )
 
 
 def _manifest_path(type_: str, slug: str, content_hash: str) -> Path:
-    return _cache_root(type_, slug, content_hash) / "manifest.json"
+    return _confined_cache_path(
+        _cache_root(type_, slug, content_hash) / "manifest.json"
+    )
 
 
 def _slug_lock_key(type_: str, slug: str) -> str:
@@ -257,22 +297,31 @@ def _release_lock(type_: str, slug: str, content_hash: str) -> None:
 
 
 def _safe_remove(path: Path, expected_parent: Path) -> None:
-    if path.parent != expected_parent or (not path.exists() and not path.is_symlink()):
+    confined_parent = _confined_cache_path(expected_parent)
+    lexical_path = path.absolute()
+    if lexical_path.parent.resolve(strict=False) != confined_parent:
         return
-    if path.is_symlink() or path.is_file():
-        path.unlink(missing_ok=True)
+    if not lexical_path.exists() and not lexical_path.is_symlink():
         return
-    if path.is_dir():
-        shutil.rmtree(path)
+    if lexical_path.is_symlink():
+        lexical_path.unlink(missing_ok=True)
+        return
+    confined_path = _confined_cache_path(lexical_path)
+    if confined_path.is_file():
+        confined_path.unlink(missing_ok=True)
+        return
+    if confined_path.is_dir():
+        shutil.rmtree(confined_path)
 
 
 def _cleanup_cache_versions() -> None:
-    TTS_DIR.mkdir(parents=True, exist_ok=True)
-    for child in TTS_DIR.iterdir():
+    cache_base = _cache_base()
+    cache_base.mkdir(parents=True, exist_ok=True)
+    for child in cache_base.iterdir():
         if child.name in VALID_TYPES or (
             VERSION_DIR_RE.fullmatch(child.name) and child.name != CACHE_DIRNAME
         ):
-            _safe_remove(child, TTS_DIR)
+            _safe_remove(child, cache_base)
 
 
 def _delete_stale_hashes(type_: str, slug: str, content_hash: str) -> None:
@@ -293,20 +342,24 @@ def _reset_outputs(type_: str, slug: str, content_hash: str) -> None:
 
 
 def _atomic_json_write(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(f"{path.suffix}.tmp")
+    confined_path = _confined_cache_path(path)
+    confined_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = _confined_cache_path(
+        confined_path.with_suffix(f"{confined_path.suffix}.tmp")
+    )
     temporary.write_text(
         json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
         encoding="utf-8",
     )
-    temporary.replace(path)
+    temporary.replace(confined_path)
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
-    if not path.exists():
+    confined_path = _confined_cache_path(path)
+    if not confined_path.exists():
         return None
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = json.loads(confined_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
     return payload if isinstance(payload, dict) else None

--- a/tts/server.py
+++ b/tts/server.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import re
 import shutil
 import threading
@@ -189,18 +190,31 @@ def _version_root() -> Path:
 
 def _cache_base() -> Path:
     """Return the canonical cache root used for containment checks."""
-    return TTS_DIR.resolve(strict=False)
+    return Path(os.path.realpath(os.fspath(TTS_DIR)))
 
 
 def _confined_cache_path(path: Path) -> Path:
-    """Resolve a cache path and reject traversal or symlink escapes."""
-    cache_base = _cache_base()
-    candidate = path.resolve(strict=False)
-    try:
-        candidate.relative_to(cache_base)
-    except ValueError as error:
-        raise ValueError("TTS cache path escapes the cache root") from error
-    return candidate
+    """Normalize a cache path and reject traversal or symlink escapes."""
+    cache_base = os.path.realpath(os.fspath(TTS_DIR))
+    cache_prefix = f"{cache_base}{os.sep}"
+    candidate = os.path.realpath(os.fspath(path))
+    if not candidate.startswith(cache_prefix):
+        raise ValueError("TTS cache path escapes the cache root")
+    return Path(candidate)
+
+
+def _confined_cache_entry(path: Path) -> Path:
+    """Validate a cache entry path without following its final symlink."""
+    cache_base = os.path.realpath(os.fspath(TTS_DIR))
+    cache_prefix = f"{cache_base}{os.sep}"
+    candidate = os.path.abspath(os.fspath(path))
+    if not candidate.startswith(cache_prefix):
+        raise ValueError("TTS cache path escapes the cache root")
+
+    actual_parent = os.path.realpath(os.path.dirname(candidate))
+    if actual_parent != cache_base and not actual_parent.startswith(cache_prefix):
+        raise ValueError("TTS cache parent escapes the cache root")
+    return Path(candidate)
 
 
 def _validate_cache_components(type_: str, slug: str, content_hash: str) -> None:
@@ -297,16 +311,22 @@ def _release_lock(type_: str, slug: str, content_hash: str) -> None:
 
 
 def _safe_remove(path: Path, expected_parent: Path) -> None:
-    confined_parent = _confined_cache_path(expected_parent)
-    lexical_path = path.absolute()
-    if lexical_path.parent.resolve(strict=False) != confined_parent:
-        return
-    if not lexical_path.exists() and not lexical_path.is_symlink():
+    cache_base = _cache_base()
+    confined_parent = (
+        cache_base
+        if expected_parent == cache_base
+        else _confined_cache_path(expected_parent)
+    )
+    lexical_path = _confined_cache_entry(path)
+    actual_parent = Path(os.path.realpath(os.fspath(lexical_path.parent)))
+    if actual_parent != confined_parent:
         return
     if lexical_path.is_symlink():
         lexical_path.unlink(missing_ok=True)
         return
     confined_path = _confined_cache_path(lexical_path)
+    if not confined_path.exists():
+        return
     if confined_path.is_file():
         confined_path.unlink(missing_ok=True)
         return

--- a/tts/tests/test_server.py
+++ b/tts/tests/test_server.py
@@ -251,6 +251,23 @@ class TtsServerTest(unittest.TestCase):
             self.assertTrue((root / CACHE_DIRNAME).exists())
             self.assertTrue((root / "keep-me").exists())
 
+    def test_startup_unlinks_legacy_symlinks_without_touching_their_targets(self):
+        with (
+            tempfile.TemporaryDirectory() as temporary,
+            tempfile.TemporaryDirectory() as external,
+        ):
+            root = Path(temporary)
+            external_root = Path(external)
+            protected = external_root / "protected.txt"
+            protected.write_text("keep", encoding="utf-8")
+            (root / "cache-v1-3").symlink_to(external_root, target_is_directory=True)
+
+            with patch.object(server, "TTS_DIR", root):
+                _cleanup_cache_versions()
+
+            self.assertFalse((root / "cache-v1-3").exists())
+            self.assertEqual(protected.read_text(encoding="utf-8"), "keep")
+
     def test_new_generation_deletes_stale_hashes_for_the_same_slug_only(self):
         current_hash = "a" * 64
         stale_hash = "b" * 64
@@ -269,6 +286,88 @@ class TtsServerTest(unittest.TestCase):
                 self.assertTrue(current.exists())
                 self.assertFalse(stale.exists())
                 self.assertTrue(other_slug.exists())
+
+    def test_stale_hash_cleanup_unlinks_symlinks_without_removing_targets(self):
+        current_hash = "a" * 64
+        stale_hash = "b" * 64
+        with (
+            tempfile.TemporaryDirectory() as temporary,
+            tempfile.TemporaryDirectory() as external,
+        ):
+            root = Path(temporary)
+            external_root = Path(external)
+            protected = external_root / "protected.txt"
+            protected.write_text("keep", encoding="utf-8")
+
+            with patch.object(server, "TTS_DIR", root):
+                slug_root = server._slug_root("lore", "story")
+                slug_root.mkdir(parents=True)
+                (slug_root / stale_hash).symlink_to(
+                    external_root, target_is_directory=True
+                )
+
+                _delete_stale_hashes("lore", "story", current_hash)
+
+                self.assertFalse((slug_root / stale_hash).exists())
+                self.assertEqual(protected.read_text(encoding="utf-8"), "keep")
+
+    def test_cache_paths_reject_untrusted_components_and_parent_traversal(self):
+        valid_hash = "a" * 64
+        with (
+            tempfile.TemporaryDirectory() as temporary,
+            tempfile.TemporaryDirectory() as external,
+        ):
+            root = Path(temporary)
+            outside = Path(external) / "outside.json"
+            outside.write_text("protected", encoding="utf-8")
+            with patch.object(server, "TTS_DIR", root):
+                for invalid_path in (
+                    lambda: server._cache_path("../../tmp", "post", valid_hash),
+                    lambda: server._cache_path("blog", "../post", valid_hash),
+                    lambda: server._cache_path("blog", "post", "../escape"),
+                    lambda: server._chunk_path("blog", "post", valid_hash, -1),
+                ):
+                    with self.assertRaises(ValueError):
+                        invalid_path()
+
+                with self.assertRaises(ValueError):
+                    server._atomic_json_write(outside, {"changed": True})
+                with self.assertRaises(ValueError):
+                    server._read_json(outside)
+                self.assertEqual(outside.read_text(encoding="utf-8"), "protected")
+
+    def test_cache_paths_reject_symlink_escapes_for_reads_and_writes(self):
+        content_hash = "a" * 64
+        with (
+            tempfile.TemporaryDirectory() as temporary,
+            tempfile.TemporaryDirectory() as external,
+        ):
+            root = Path(temporary)
+            external_root = Path(external)
+            protected = external_root / "status.json"
+            protected.write_text('{"protected":true}', encoding="utf-8")
+            type_root = root / CACHE_DIRNAME / "blog"
+            type_root.mkdir(parents=True)
+            (type_root / "escape").symlink_to(
+                external_root, target_is_directory=True
+            )
+
+            with patch.object(server, "TTS_DIR", root):
+                with self.assertRaises(ValueError):
+                    server._status_path("blog", "escape", content_hash)
+
+                cache_root = server._cache_root("blog", "safe-post", content_hash)
+                cache_root.mkdir(parents=True)
+                status_link = cache_root / "status.json"
+                status_link.symlink_to(protected)
+                with self.assertRaises(ValueError):
+                    server._atomic_json_write(status_link, {"changed": True})
+                with self.assertRaises(ValueError):
+                    server._read_json(status_link)
+
+            self.assertEqual(
+                protected.read_text(encoding="utf-8"), '{"protected":true}'
+            )
 
     def test_cache_version_is_explicit(self):
         self.assertEqual(CACHE_VERSION, "1-4")

--- a/tts/tests/test_server.py
+++ b/tts/tests/test_server.py
@@ -317,9 +317,13 @@ class TtsServerTest(unittest.TestCase):
             tempfile.TemporaryDirectory() as temporary,
             tempfile.TemporaryDirectory() as external,
         ):
-            root = Path(temporary)
+            root = Path(temporary) / "tts"
+            root.mkdir()
             outside = Path(external) / "outside.json"
             outside.write_text("protected", encoding="utf-8")
+            prefix_sibling = Path(temporary) / "tts-escape" / "outside.json"
+            prefix_sibling.parent.mkdir()
+            prefix_sibling.write_text("protected", encoding="utf-8")
             with patch.object(server, "TTS_DIR", root):
                 for invalid_path in (
                     lambda: server._cache_path("../../tmp", "post", valid_hash),
@@ -334,7 +338,12 @@ class TtsServerTest(unittest.TestCase):
                     server._atomic_json_write(outside, {"changed": True})
                 with self.assertRaises(ValueError):
                     server._read_json(outside)
+                with self.assertRaises(ValueError):
+                    server._atomic_json_write(prefix_sibling, {"changed": True})
                 self.assertEqual(outside.read_text(encoding="utf-8"), "protected")
+                self.assertEqual(
+                    prefix_sibling.read_text(encoding="utf-8"), "protected"
+                )
 
     def test_cache_paths_reject_symlink_escapes_for_reads_and_writes(self):
         content_hash = "a" * 64


### PR DESCRIPTION
## Summary

- overhaul prose-first TTS generation and timed range delivery
- confine cache filesystem access beneath the TTS cache root
- add regression coverage for traversal and symlink escape attempts
- defer status polling until the current document hash is available

## Verification

- `PYTHONPATH=tts uv run --project tts python -m unittest tts.tests.test_server`
- `bun test components/blog/TtsPlayer.test.tsx`
- `bun lint`
- CodeQL 2.26.1 `py/path-injection` query: 0 results
- GitHub CodeQL rescan pending after the committed branch is published

---
<!-- midori-ai-agents-runner-pr-footer -->
Created by [Midori AI Agents Runner](https://github.com/Midori-AI-OSS/Agents-Runner)
Agent Used: [OpenAI Codex](https://github.com/openai/codex)
Related: [Midori AI Monorepo](https://github.com/Midori-AI-OSS/Midori-AI)
