### PR TITLE
[blog] Add August 4 development update

### DIFF
--- a/blog/posts/2026-08-04.md
+++ b/blog/posts/2026-08-04.md
@@ -1,0 +1,253 @@
+---
+title: "the radio used four gigs of memory"
+summary: "I fixed a big vibes memory problem, cleaned up some tts bugs, and found two more agents runner bugs."
+tags: [website-blog, radio, vibes, tts, agents-runner]
+cover_image: /blog/2026-08-04.png
+author: Riley Midori
+---
+
+hello friends.
+
+so I left the radio running for about three days.
+
+it ended up using more than 4 GB of memory.
+
+that is way too much.
+
+the radio does not need four gigs just to show some moving shapes.
+
+I thought `Vibes` was doing it.
+
+yea. it was `Vibes`.
+
+a few things were going wrong at the same time.
+
+the canvas kept making new stuff when it could reuse old stuff. some effects made the same shapes again every frame. some animation work did not fully stop when the page was done with it.
+
+it worked fine for a short time.
+
+three days was not fine.
+
+the canvas reuses more stuff now.
+
+it makes one extra canvas for scene changes and keeps using it. it does not make a new one over and over.
+
+the animation stops when the tab is hidden.
+
+when the tab comes back, the timing starts in the right place. it does not try to catch up for all the time it was hidden.
+
+when `Vibes` closes, the animation stops and the old scene data gets cleared.
+
+so it should really stop now.
+
+there was another bug right after that fix.
+
+the animation ran for one frame.
+
+then it stopped.
+
+the code was trying to stop two frames from running at once.
+
+that part was fine.
+
+but it never cleared the old frame after it was done.
+
+so the code kept thinking a frame was still waiting.
+
+it was not.
+
+that is fixed now.
+
+a lot of the effects also do less work now.
+
+seventeen effects save the parts that stay the same. stuff like dots, random numbers, points, and wireframe edges.
+
+they reuse that stuff instead of making it again every frame.
+
+there is a cache for it.
+
+the cache has a limit.
+
+I do not want to fix one memory problem by making a new memory problem.
+
+the saved shapes also do not keep the colors from one song. the colors still change when the album art changes.
+
+the wireframes are smaller now.
+
+they move slower too.
+
+a scene can still have a few effects. it just does not pile a bunch of wireframes into the same scene anymore.
+
+that was too much stuff on the screen.
+
+the tunnel also had a weird bug.
+
+sometimes one of the rings would suddenly get huge.
+
+just a giant ring showing up.
+
+the depth math was wrong in some spots.
+
+that is fixed now.
+
+the tunnel is slower too.
+
+the wireframe colors blend into each other now.
+
+before, they jumped from one color to the next.
+
+it looked kinda rough.
+
+now the colors change more smoothly.
+
+I left the radio running again.
+
+so far it is not trying to eat the whole computer.
+
+good.
+
+there are some smaller `TTS` fixes too.
+
+inline code was not being read out loud.
+
+a line could have a word like `spells` in it.
+
+you could see the word on the page.
+
+the voice skipped it.
+
+so the line sounded like it had a hole in it.
+
+inline code is spoken now.
+
+big code blocks are still skipped. this only changes code words inside normal lines.
+
+the text highlight also had a problem when the audio changed chunks.
+
+one chunk would end.
+
+the next chunk would start loading.
+
+the highlight could move before the new audio started.
+
+so the page looked ahead of the voice.
+
+now the old highlight clears while the audio changes.
+
+the player waits until the next chunk is really playing.
+
+then the highlight starts again.
+
+there was also a problem with the pause between paragraphs.
+
+the voice waits for half a second between paragraphs.
+
+before, that pause did not belong to any line.
+
+the page could stop showing the exact line and light up a bigger block of text instead.
+
+now the pause stays with the line before it.
+
+that line stays lit during the pause.
+
+then the next line lights up when the voice starts again.
+
+this also works when the paragraph break is between two audio chunks.
+
+that was the annoying one.
+
+so yea.
+
+the big `TTS` change from the last post is still there.
+
+these fixes just make the words, audio, and highlight match better.
+
+there are also two `Agents Runner` fixes.
+
+they are in `nightly`.
+
+they are not in `main` yet.
+
+the first fix removes a prompt rule that told sub-agents to wait for random amounts of time.
+
+it was meant to help with pacing and rate limits.
+
+mostly it made agents sit there because the prompt told them to.
+
+that rule is gone.
+
+the second fix is for the New Task form.
+
+an older task can still be getting ready in the back.
+
+maybe it is pulling a docker image or doing a preflight check.
+
+while that happens, you can start typing a new task.
+
+before the fix, the old task could finish getting ready and clear the new prompt you were typing.
+
+it could also switch the picked env back to the old task's env.
+
+which was very annoying.
+
+the old task should not reach over and erase a different task.
+
+it does not reset the form now.
+
+it also does not change the picked env.
+
+the normal reset still happens after you send a task.
+
+both fixes are in `nightly` right now.
+
+I also have two new runner bugs open.
+
+the first one is about `gh auth status`.
+
+I have 20+ envs set up.
+
+I left runner open while I took a nap.
+
+when I came back, github was logged out.
+
+I do not know the full cause yet.
+
+there were a lot of auth checks running in the back, so that looks like part of it.
+
+but I do not have the full answer yet.
+
+checking if github is logged in should not log github out.
+
+the second bug is about old tasks.
+
+some tasks got killed or stopped.
+
+their task files are still saved.
+
+but runner cannot make a PR from them later.
+
+I do not know where that breaks yet either.
+
+both bugs are still open.
+
+I am still looking into them.
+
+so yea.
+
+the radio uses less memory now.
+
+`TTS` reads the words it was skipping.
+
+the text highlight follows the audio better.
+
+runner has two fixes in `nightly`.
+
+runner also has two open bugs I still need to figure out.
+
+and the radio is not using four gigs of memory anymore.
+
+I am pretty happy about that.
+
+thanks for reading.
+
+- Riley Midori


### PR DESCRIPTION
## what changed

- adds Riley's August 4 dev post
- covers the Vibes memory fix and the TTS follow-up fixes
- notes the two Agents Runner fixes in `nightly`
- notes the two open Runner bugs

## notes

- uses the final Riley-voice draft from chat
- adds only `blog/posts/2026-08-04.md`
- points at `/blog/2026-08-04.png` for the cover image; the image is not in this PR
